### PR TITLE
fix: session stability — process group kill, batch do-file, cancel co…

### DIFF
--- a/src/stata_ai_fusion/stata_session.py
+++ b/src/stata_ai_fusion/stata_session.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
@@ -287,10 +288,17 @@ class StataSession:
             encoding="utf-8",
             timeout=_START_TIMEOUT,
             env={**os.environ, "TERM": "dumb"},
+            preexec_fn=os.setsid,
         )
 
         # Wait for the initial prompt.
         child.expect(r"\. $", timeout=_START_TIMEOUT)
+
+        # Disable GUI graph windows so Stata never blocks waiting for
+        # user interaction in the background.
+        child.sendline("set graphics off")
+        child.expect(r"\. $", timeout=_START_TIMEOUT)
+
         return child
 
     async def close(self) -> None:
@@ -334,16 +342,29 @@ class StataSession:
     # ------------------------------------------------------------------
 
     def _kill_process(self) -> None:
-        """Forcefully kill the Stata process and mark for restart.
+        """Forcefully kill the Stata process *and all its children*, then
+        mark the session for restart.
 
-        Called after a timeout or other unrecoverable state corruption so
-        that :meth:`_ensure_alive` will spawn a clean process on the next
-        :meth:`execute` call.
+        Stata-MP spawns helper worker processes.  A plain ``terminate()``
+        only signals the lead process; the workers can linger and hold the
+        licence.  By sending SIGKILL to the entire process **group**
+        (created via ``os.setsid`` in :meth:`_spawn_process`) we guarantee
+        a clean slate.
         """
         if self._process is not None:
             try:
-                if self._process.isalive():
-                    self._process.terminate(force=True)
+                pid = self._process.pid
+                if pid and self._process.isalive():
+                    try:
+                        os.killpg(os.getpgid(pid), signal.SIGKILL)
+                        log.debug(
+                            "Killed process group for session %s (pid %d)",
+                            self.session_id,
+                            pid,
+                        )
+                    except (ProcessLookupError, PermissionError):
+                        # Race: process already exited — fall back.
+                        self._process.terminate(force=True)
             except Exception:
                 log.warning(
                     "Error killing session %s process",
@@ -352,6 +373,19 @@ class StataSession:
                 )
             self._process = None
         self._started = False
+
+    def send_interrupt(self) -> bool:
+        """Send SIGINT (Ctrl-C) to the running Stata process.
+
+        Returns ``True`` if the signal was sent, ``False`` if the process
+        is not alive.  This is a *gentle* cancellation — Stata will abort
+        the current command but the session stays usable.
+        """
+        if self._process is not None and self._process.isalive():
+            self._process.sendintr()
+            log.info("Sent interrupt to session %s", self.session_id)
+            return True
+        return False
 
     # ------------------------------------------------------------------
     # Auto-restart
@@ -424,16 +458,37 @@ class StataSession:
                 )
             except pexpect.TIMEOUT:
                 elapsed = time.monotonic() - start_time
+                # Capture whatever partial output Stata produced before
+                # the timeout — this often contains useful progress info.
+                partial = ""
+                try:
+                    if self._process is not None and self._process.before:
+                        partial = strip_smcl(self._process.before).strip()
+                except Exception:
+                    pass
+
                 # After a timeout the pexpect buffer is in an unknown
                 # state (partial output, Stata may still be running the
                 # timed-out command).  Kill the process so _ensure_alive()
                 # spawns a clean one on the next call.
                 self._kill_process()
+
+                hint = (
+                    f"Command timed out after {timeout}s. "
+                    "The session has been reset and will auto-restart on "
+                    "the next command.  Tips:\n"
+                    "  • Increase the timeout parameter.\n"
+                    "  • For long-running commands (bootstrap, mixed models) "
+                    "use the run_do_file tool which runs in batch mode.\n"
+                    "  • Use stata_cancel_command to abort a running command "
+                    "without losing the session."
+                )
+                output_text = f"{hint}\n\n--- partial output ---\n{partial}" if partial else hint
+
                 return ExecutionResult(
-                    output="",
+                    output=output_text,
                     return_code=1,
-                    error_message=f"Command timed out after {timeout}s. "
-                    "Session will auto-restart on next command.",
+                    error_message=hint,
                     error_code=None,
                     graphs=[],
                     execution_time=elapsed,

--- a/src/stata_ai_fusion/tools/__init__.py
+++ b/src/stata_ai_fusion/tools/__init__.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from mcp.types import ImageContent, TextContent, Tool
 
 from . import (
+    cancel_command,
     codebook,
     export_graph,
     get_results,
@@ -42,6 +43,7 @@ _TOOL_MODULES = [
     export_graph,
     search_log,
     install_package,
+    cancel_command,
 ]
 
 _TOOL_REGISTRY: dict[str, tuple[Tool, object]] = {}

--- a/src/stata_ai_fusion/tools/cancel_command.py
+++ b/src/stata_ai_fusion/tools/cancel_command.py
@@ -1,0 +1,87 @@
+"""Cancel command tool.
+
+Provides the ``stata_cancel_command`` MCP tool that sends SIGINT (Ctrl-C) to
+the running Stata process, aborting the current command without destroying the
+session.  This is the preferred way to stop a long-running interactive command
+(e.g. bootstrap, simulate) while keeping the data in memory.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from mcp.types import TextContent, Tool
+
+log = logging.getLogger(__name__)
+
+TOOL_NAME = "stata_cancel_command"
+
+TOOL_DEF = Tool(
+    name=TOOL_NAME,
+    description=(
+        "Send Ctrl-C (SIGINT) to cancel the currently running Stata command "
+        "without killing the session. The dataset in memory is preserved. "
+        "Only works for interactive sessions."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "description": "Session identifier. Default 'default'.",
+                "default": "default",
+            },
+        },
+    },
+)
+
+
+def register(server, session_manager) -> None:  # noqa: ANN001
+    """Registration is handled by the central dispatcher in tools/__init__.py."""
+
+
+async def handle(
+    session_manager,  # noqa: ANN001
+    arguments: dict,
+) -> list[TextContent]:
+    """Send an interrupt (SIGINT) to the Stata session."""
+    session_id: str = arguments.get("session_id", "default")
+
+    # Look up the session *without* creating a new one or blocking on the
+    # session lock (get_or_create would block if a command is running).
+    session = session_manager._sessions.get(session_id)
+
+    if session is None:
+        return [
+            TextContent(
+                type="text",
+                text=f"No active session with id '{session_id}'.",
+            )
+        ]
+
+    # Only interactive sessions support send_interrupt.
+    if not hasattr(session, "send_interrupt"):
+        return [
+            TextContent(
+                type="text",
+                text="Cancel is only supported for interactive sessions, "
+                "not batch sessions.",
+            )
+        ]
+
+    sent = session.send_interrupt()
+    if sent:
+        return [
+            TextContent(
+                type="text",
+                text=f"Interrupt sent to session '{session_id}'. "
+                "Stata will abort the current command. The session and "
+                "data in memory are preserved.",
+            )
+        ]
+    return [
+        TextContent(
+            type="text",
+            text=f"Session '{session_id}' has no running process to interrupt.",
+        )
+    ]

--- a/src/stata_ai_fusion/tools/run_do_file.py
+++ b/src/stata_ai_fusion/tools/run_do_file.py
@@ -1,21 +1,31 @@
-"""Run .do file tool.
+"""Run .do file tool — batch-mode implementation.
 
 Provides the ``stata_run_do_file`` MCP tool that executes an existing Stata
-do-file in a managed session, returning text output and any generated graphs.
+do-file in **batch mode** (``subprocess.Popen``) rather than through the
+interactive pexpect session.  Batch mode is more reliable for long-running
+scripts (bootstrap, mixed models, simulations) because it avoids the
+prompt-matching heuristics of pexpect.
+
+Text output is read from the ``.log`` file Stata produces; graphs are
+detected via the :class:`GraphCache` snapshot-diff mechanism.
 """
 
 from __future__ import annotations
 
+import base64
 import logging
+import os
+import signal
+import subprocess
+import time
+import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+import anyio
 from mcp.types import ImageContent, TextContent, Tool
 
-if TYPE_CHECKING:
-    from mcp.server import Server
-
-    from ..stata_session import SessionManager
+from ..graph_cache import GraphCache
+from ..stata_session import _detect_error, strip_smcl
 
 log = logging.getLogger(__name__)
 
@@ -49,28 +59,30 @@ TOOL_DEF = Tool(
     },
 )
 
+# Maximum characters of Stata log output to return to the AI.
+_MAX_OUTPUT_CHARS = 30_000
 
-def register(server: Server, session_manager: SessionManager) -> None:
-    """Register the ``stata_run_do_file`` tool with the MCP server."""
-    # Registration is handled by the central dispatcher in tools/__init__.py.
-    pass
+
+def register(server, session_manager) -> None:  # noqa: ANN001
+    """Registration is handled by the central dispatcher in tools/__init__.py."""
 
 
 async def handle(
-    session_manager: SessionManager,
+    session_manager,  # noqa: ANN001
     arguments: dict,
 ) -> list[TextContent | ImageContent]:
-    """Execute a Stata .do file and return content blocks."""
+    """Execute a Stata .do file in batch mode and return content blocks."""
     raw_path: str = arguments.get("path", "")
     session_id: str = arguments.get("session_id", "default")
     timeout: int = arguments.get("timeout", 300)
+
+    # ---- Input validation ------------------------------------------------
 
     if not raw_path.strip():
         return [TextContent(type="text", text="Error: no file path provided.")]
 
     do_path = Path(raw_path).expanduser().resolve()
 
-    # Validate extension
     if do_path.suffix.lower() != ".do":
         return [
             TextContent(
@@ -79,7 +91,6 @@ async def handle(
             )
         ]
 
-    # Validate existence
     if not do_path.is_file():
         return [
             TextContent(
@@ -88,32 +99,111 @@ async def handle(
             )
         ]
 
-    try:
-        session = await session_manager.get_or_create(session_id)
-    except Exception as exc:
-        log.error("Failed to get/create session %s: %s", session_id, exc)
-        return [TextContent(type="text", text=f"Error creating session: {exc}")]
+    # ---- Resolve Stata path ---------------------------------------------
 
-    code = f'do "{do_path}"'
+    stata_path = str(session_manager.installation.path)
+
+    # ---- Prepare working directory & graph cache -------------------------
+
+    working_directory = do_path.parent
+    graph_cache = GraphCache(working_directory)
+    graph_cache.take_snapshot()
+
+    # The .log file Stata creates has the same stem as the .do file.
+    log_file = working_directory / f"{do_path.stem}.log"
+
+    # ---- Run in batch mode -----------------------------------------------
+
+    start_time = time.monotonic()
+    proc: subprocess.Popen | None = None
+
     try:
-        result = await session.execute(code, timeout=timeout)
+        def _run_batch() -> tuple[int, str]:
+            nonlocal proc
+            proc = subprocess.Popen(
+                [stata_path, "-b", "do", str(do_path)],
+                cwd=str(working_directory),
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                # Kill the entire process group.
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    proc.kill()
+                proc.wait()
+                raise
+            return proc.returncode, ""
+
+        await anyio.to_thread.run_sync(_run_batch)
+
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - start_time
+        # Try to read partial log output even after timeout.
+        partial = ""
+        if log_file.exists():
+            try:
+                partial = log_file.read_text(encoding="utf-8", errors="replace")
+                partial = strip_smcl(partial)
+                if len(partial) > _MAX_OUTPUT_CHARS:
+                    partial = partial[:_MAX_OUTPUT_CHARS] + "\n\n... (truncated)"
+            except Exception:
+                pass
+        msg = f"Do-file timed out after {timeout}s."
+        output = f"{msg}\n\n--- partial output ---\n{partial}" if partial else msg
+        return [TextContent(type="text", text=output)]
+
     except Exception as exc:
-        log.error("Execution error running %s: %s", do_path, exc)
+        log.error("Batch execution error for %s: %s", do_path, exc)
         return [TextContent(type="text", text=f"Execution error: {exc}")]
+
+    elapsed = time.monotonic() - start_time
+
+    # ---- Read log file ---------------------------------------------------
+
+    raw_output = ""
+    if log_file.exists():
+        try:
+            raw_output = log_file.read_text(encoding="utf-8", errors="replace")
+        except Exception as exc:
+            log.warning("Could not read log file %s: %s", log_file, exc)
+
+    cleaned = strip_smcl(raw_output)
+
+    # Truncate very large output.
+    if len(cleaned) > _MAX_OUTPUT_CHARS:
+        cleaned = cleaned[:_MAX_OUTPUT_CHARS] + "\n\n... (output truncated at 30,000 chars)"
+
+    # ---- Error detection -------------------------------------------------
+
+    error_message, error_code = _detect_error(cleaned)
+
+    # ---- Graph detection -------------------------------------------------
+
+    graphs = graph_cache.detect_changes()
+
+    # ---- Build response --------------------------------------------------
 
     contents: list[TextContent | ImageContent] = []
 
-    # Text output
-    output_text = result.output or ""
-    if result.error_message:
-        output_text += f"\n\n--- Stata Error ---\n{result.error_message}"
-        if result.error_code is not None:
-            output_text += f" [r({result.error_code})]"
+    # Metadata header
+    meta_line = f"[batch mode | {elapsed:.1f}s | session_id={session_id}]"
+    output_text = f"{meta_line}\n\n{cleaned}" if cleaned.strip() else meta_line
+
+    if error_message:
+        output_text += f"\n\n--- Stata Error ---\n{error_message}"
+        if error_code is not None:
+            output_text += f" [r({error_code})]"
+
     if output_text.strip():
         contents.append(TextContent(type="text", text=output_text.strip()))
 
     # Graph images
-    for graph in result.graphs:
+    for graph in graphs:
         mime = f"image/{graph.format}" if graph.format != "pdf" else "application/pdf"
         contents.append(
             ImageContent(


### PR DESCRIPTION
…mmand

- stata_session.py: spawn Stata in its own process group (os.setsid), rewrite _kill_process to kill the entire group (os.killpg), add send_interrupt() for graceful Ctrl-C cancellation, capture partial output on timeout with actionable recovery tips, disable GUI graph windows on startup (set graphics off)
- tools/run_do_file.py: rewrite to use subprocess.Popen batch mode instead of pexpect, more reliable for long-running scripts (bootstrap, mixed models), 30k char output truncation, metadata header
- tools/cancel_command.py: new stata_cancel_command tool — sends SIGINT to abort running command without killing session or losing data
- tools/__init__.py: register cancel_command in tool registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to cancel/interrupt running Stata commands while preserving session data and in-memory variables.
  
* **Improvements**
  * Enhanced timeout handling to capture and display partial output when commands exceed time limits.
  * Improved Stata do-file execution with batch-mode processing and better error detection.
  * More informative timeout messages with guidance on next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->