### PR TITLE
refactor(server): surface missing skill config via structured logs

### DIFF
--- a/src/stata_ai_fusion/server.py
+++ b/src/stata_ai_fusion/server.py
@@ -32,31 +32,91 @@ SKILL_DIR = Path(__file__).parent.parent.parent / "skill"
 
 
 def _read_skill_main() -> str:
-    """Read the SKILL.md knowledge base document."""
+    """Read the SKILL.md knowledge base document.
+
+    Returns the file's contents on success.  If the file is missing,
+    logs a WARNING (so operators see the packaging/config problem in
+    their server log) and returns a user-visible placeholder that keeps
+    the MCP resource-read contract.
+    """
     skill_path = SKILL_DIR / "SKILL.md"
     if skill_path.is_file():
-        return skill_path.read_text(encoding="utf-8")
+        try:
+            return skill_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            log.warning("Failed to read %s: %s", skill_path, exc)
+            return f"(SKILL.md unreadable: {exc.strerror or exc})"
+    log.warning(
+        "SKILL.md not found at %s — knowledge base resource will be empty. "
+        "Check that the 'skill/' directory is present in your installation.",
+        skill_path,
+    )
     return "(SKILL.md not found)"
 
 
 def _list_reference_files() -> list[Path]:
-    """List all reference markdown files in skill/references/."""
+    """List all reference markdown files in ``skill/references/``.
+
+    If the references directory is missing or unreadable, logs a
+    WARNING and returns an empty list so the MCP server still starts
+    cleanly.
+    """
     refs_dir = SKILL_DIR / "references"
     if not refs_dir.is_dir():
+        log.warning(
+            "Reference directory missing: %s — no reference topics will be advertised. "
+            "Check that the 'skill/references/' directory is present in your installation.",
+            refs_dir,
+        )
         return []
-    return sorted(refs_dir.glob("*.md"))
+    try:
+        return sorted(refs_dir.glob("*.md"))
+    except OSError as exc:
+        log.warning("Failed to scan reference directory %s: %s", refs_dir, exc)
+        return []
 
 
 def _read_reference(topic: str) -> str | None:
-    """Read a single reference document by topic slug."""
+    """Read a single reference document by topic slug.
+
+    Returns the document's text on success, or ``None`` if no matching
+    file exists (case-insensitive).  A missing references directory
+    surfaces as a WARNING (emitted by :func:`_list_reference_files`)
+    so both the list and single-topic access paths expose the same
+    operator-visible signal for that root cause.
+
+    The exact-path read is attempted *before* listing so that a
+    directory with execute-only permissions (listable=False but
+    openable by known name) still succeeds for the happy path.
+    """
     refs_dir = SKILL_DIR / "references"
+
+    # Fast path: try the exact filename first.  This succeeds even on
+    # directories that block ``glob()`` / ``readdir()`` but allow
+    # ``open()`` of a known path (rare but real: POSIX execute-only).
     candidate = refs_dir / f"{topic}.md"
     if candidate.is_file():
-        return candidate.read_text(encoding="utf-8")
-    # Try case-insensitive match
-    for p in refs_dir.glob("*.md"):
-        if p.stem.lower() == topic.lower():
-            return p.read_text(encoding="utf-8")
+        try:
+            return candidate.read_text(encoding="utf-8")
+        except OSError as exc:
+            log.warning("Failed to read reference %s: %s", candidate, exc)
+            return None
+
+    # Fall back to listing for the case-insensitive match.  Calling
+    # :func:`_list_reference_files` is also what surfaces a missing /
+    # unreadable references directory to operators.
+    ref_files = _list_reference_files()
+
+    topic_lower = topic.lower()
+    for p in ref_files:
+        if p.stem.lower() == topic_lower:
+            try:
+                return p.read_text(encoding="utf-8")
+            except OSError as exc:
+                log.warning("Failed to read reference %s: %s", p, exc)
+                return None
+
+    log.debug("Reference topic not found: %s", topic)
     return None
 
 
@@ -122,8 +182,12 @@ def register_resources(server: Server) -> None:
             content = _read_reference(topic)
             if content is not None:
                 return content
+            # _read_reference() already logs at DEBUG for an unknown topic
+            # and at WARNING if the underlying references directory is
+            # missing — don't add a duplicate INFO log here.
             return f"(reference not found: {topic})"
 
+        log.error("Unknown MCP resource URI requested: %s", uri_str)
         return f"(unknown resource: {uri_str})"
 
 
@@ -182,8 +246,12 @@ async def serve() -> None:
     for sig in (signal.SIGINT, signal.SIGTERM):
         try:
             signal.signal(sig, _signal_handler)
-        except (OSError, ValueError):
-            pass  # Not all signals available on all platforms
+        except (OSError, ValueError) as exc:
+            # Windows restricts which signals can be set from non-main threads
+            # or in certain execution contexts (e.g. pytest runners).  Log at
+            # DEBUG rather than swallowing silently so the cause is visible
+            # when troubleshooting unexpected shutdown behavior.
+            log.debug("Could not install handler for %s: %s", signal.Signals(sig).name, exc)
 
     # -- Run ---------------------------------------------------------------
     log.info("MCP server ready, waiting for connections via stdio")

--- a/tests/test_server_resources.py
+++ b/tests/test_server_resources.py
@@ -1,0 +1,307 @@
+"""Tests for the MCP resource helpers in ``server.py``.
+
+These cover the skill knowledge-base accessors that previously returned
+placeholder strings silently on missing config.  The fix is to emit
+WARNING-level logs when files/directories are missing so operators see
+the underlying cause in their server log, while keeping the user-facing
+return strings backwards-compatible with the MCP resource-read contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from stata_ai_fusion import server as server_module
+
+
+@pytest.fixture
+def empty_skill_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect SKILL_DIR to an empty temp directory (no SKILL.md, no refs/)."""
+    monkeypatch.setattr(server_module, "SKILL_DIR", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def skill_with_main(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """SKILL_DIR with a SKILL.md but no references directory."""
+    (tmp_path / "SKILL.md").write_text("# Stata Skill\n\nHello.\n", encoding="utf-8")
+    monkeypatch.setattr(server_module, "SKILL_DIR", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def skill_with_refs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """SKILL_DIR with SKILL.md and a references/ directory containing a doc."""
+    (tmp_path / "SKILL.md").write_text("# Main\n", encoding="utf-8")
+    refs = tmp_path / "references"
+    refs.mkdir()
+    (refs / "regression.md").write_text("# Regression\n\nUse ``regress``.\n", encoding="utf-8")
+    (refs / "DataCleaning.md").write_text("# Data Cleaning\n", encoding="utf-8")
+    monkeypatch.setattr(server_module, "SKILL_DIR", tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# _read_skill_main
+# ---------------------------------------------------------------------------
+
+
+class TestReadSkillMain:
+    """Behavior of :func:`server._read_skill_main`."""
+
+    def test_returns_file_content_when_present(self, skill_with_main: Path) -> None:
+        """Happy path: SKILL.md content is returned verbatim."""
+        assert server_module._read_skill_main() == "# Stata Skill\n\nHello.\n"
+
+    def test_logs_warning_when_missing(
+        self, empty_skill_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Missing SKILL.md must emit a WARNING so operators see the config gap."""
+        with caplog.at_level(logging.WARNING):
+            result = server_module._read_skill_main()
+        assert "(SKILL.md not found)" in result
+        assert any("SKILL.md not found" in rec.message for rec in caplog.records)
+        assert any(rec.levelno == logging.WARNING for rec in caplog.records)
+
+    def test_logs_warning_on_ioerror(
+        self, skill_with_main: Path, monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If ``read_text`` raises, we log WARNING and return a usable fallback."""
+        original_read = Path.read_text
+
+        def failing_read(self: Path, *args: object, **kwargs: object) -> str:
+            if self.name == "SKILL.md":
+                raise PermissionError(13, "Permission denied")
+            return original_read(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", failing_read)
+
+        with caplog.at_level(logging.WARNING):
+            result = server_module._read_skill_main()
+        assert "unreadable" in result
+        assert any("Failed to read" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _list_reference_files
+# ---------------------------------------------------------------------------
+
+
+class TestListReferenceFiles:
+    """Behavior of :func:`server._list_reference_files`."""
+
+    def test_returns_sorted_list_when_present(self, skill_with_refs: Path) -> None:
+        """Returns all .md files sorted alphabetically."""
+        files = server_module._list_reference_files()
+        assert [p.name for p in files] == ["DataCleaning.md", "regression.md"]
+
+    def test_warns_when_refs_dir_missing(
+        self, skill_with_main: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Missing references/ must emit a WARNING and return []."""
+        with caplog.at_level(logging.WARNING):
+            files = server_module._list_reference_files()
+        assert files == []
+        assert any("Reference directory missing" in rec.message for rec in caplog.records)
+
+    def test_warns_on_glob_oserror(
+        self, skill_with_refs: Path, monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If scanning the references directory itself raises OSError
+        (e.g. unreadable directory), log WARNING and return [] instead of
+        letting the exception escape into the MCP protocol layer."""
+        original_glob = Path.glob
+
+        def failing_glob(self: Path, pattern: str, *args: object, **kwargs: object):
+            if self.name == "references":
+                raise PermissionError(13, "Permission denied")
+            return original_glob(self, pattern, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "glob", failing_glob)
+
+        with caplog.at_level(logging.WARNING):
+            files = server_module._list_reference_files()
+        assert files == []
+        assert any(
+            "Failed to scan reference directory" in rec.message for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# _read_reference
+# ---------------------------------------------------------------------------
+
+
+class TestReadReference:
+    """Behavior of :func:`server._read_reference`."""
+
+    def test_returns_content_for_exact_match(self, skill_with_refs: Path) -> None:
+        content = server_module._read_reference("regression")
+        assert content is not None
+        assert "Use ``regress``" in content
+
+    def test_returns_content_for_case_insensitive_match(self, skill_with_refs: Path) -> None:
+        """Callers that pass a slightly different casing still resolve."""
+        content = server_module._read_reference("datacleaning")
+        assert content is not None
+        assert "Data Cleaning" in content
+
+    def test_returns_none_for_unknown_topic(self, skill_with_refs: Path) -> None:
+        assert server_module._read_reference("no-such-topic") is None
+
+    def test_returns_none_when_refs_dir_missing(
+        self, skill_with_main: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No references/ dir → None AND a WARNING, so a direct client
+        read of ``stata://skill/references/X`` also surfaces the config
+        problem (not just a list-then-read sequence)."""
+        with caplog.at_level(logging.WARNING):
+            result = server_module._read_reference("whatever")
+        assert result is None
+        assert any(
+            "Reference directory missing" in rec.message for rec in caplog.records
+        )
+
+    def test_succeeds_when_dir_not_listable_but_file_readable(
+        self, skill_with_refs: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Execute-only directories (listable=False, readable-by-known-name=True)
+        must still resolve exact-topic reads.  Simulated by making glob() fail
+        while leaving read_text() working."""
+        def failing_glob(self: Path, pattern: str, *args: object, **kwargs: object):
+            if self.name == "references":
+                raise PermissionError(13, "Permission denied")
+            return Path.__dict__["glob"].__wrapped__(self, pattern, *args, **kwargs) \
+                if hasattr(Path.__dict__["glob"], "__wrapped__") else iter([])
+        monkeypatch.setattr(Path, "glob", failing_glob)
+
+        # Exact-file path still succeeds because we try the candidate
+        # filename before invoking the list helper.
+        content = server_module._read_reference("regression")
+        assert content is not None
+        assert "Use ``regress``" in content
+
+    def test_empty_refs_dir_logs_debug_for_miss(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When references/ exists but is empty, a topic miss still
+        emits a DEBUG log so operators who raise verbosity can see it,
+        and no WARNING is emitted (empty != missing)."""
+        (tmp_path / "SKILL.md").write_text("# Main\n", encoding="utf-8")
+        (tmp_path / "references").mkdir()
+        monkeypatch.setattr(server_module, "SKILL_DIR", tmp_path)
+
+        with caplog.at_level(logging.DEBUG):
+            result = server_module._read_reference("whatever")
+
+        assert result is None
+        assert any(
+            "Reference topic not found" in rec.message and rec.levelno == logging.DEBUG
+            for rec in caplog.records
+        )
+        # Empty directory is not the same as missing — must not emit WARNING.
+        assert not any(
+            "Reference directory missing" in rec.message for rec in caplog.records
+        )
+
+    def test_logs_warning_on_ioerror(
+        self, skill_with_refs: Path, monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """File exists but read fails → WARNING log and None return."""
+        def failing_read(self: Path, *args: object, **kwargs: object) -> str:
+            raise PermissionError(13, "Permission denied")
+        monkeypatch.setattr(Path, "read_text", failing_read)
+
+        with caplog.at_level(logging.WARNING):
+            result = server_module._read_reference("regression")
+        assert result is None
+        assert any("Failed to read reference" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# handle_read_resource (via register_resources)
+# ---------------------------------------------------------------------------
+
+
+class _StubServer:
+    """Minimal stand-in for ``mcp.server.Server`` that just captures decorated handlers."""
+
+    def __init__(self) -> None:
+        self.list_handler = None
+        self.read_handler = None
+
+    def list_resources(self):
+        def decorator(func):
+            self.list_handler = func
+            return func
+        return decorator
+
+    def read_resource(self):
+        def decorator(func):
+            self.read_handler = func
+            return func
+        return decorator
+
+
+class TestHandleReadResource:
+    """End-to-end behavior of the MCP resource read handler."""
+
+    @pytest.fixture
+    def handlers(self, skill_with_refs: Path) -> _StubServer:
+        stub = _StubServer()
+        server_module.register_resources(stub)  # type: ignore[arg-type]
+        assert stub.read_handler is not None
+        return stub
+
+    async def test_main_resource_returns_skill_content(self, handlers: _StubServer) -> None:
+        result = await handlers.read_handler("stata://skill/main")
+        assert result.startswith("# Main")
+
+    async def test_references_list_returns_topic_names(self, handlers: _StubServer) -> None:
+        result = await handlers.read_handler("stata://skill/references")
+        assert "regression" in result
+        assert "DataCleaning" in result
+
+    async def test_references_list_placeholder_when_empty(
+        self, skill_with_main: Path
+    ) -> None:
+        stub = _StubServer()
+        server_module.register_resources(stub)  # type: ignore[arg-type]
+        result = await stub.read_handler("stata://skill/references")
+        assert "(no reference files found)" in result
+
+    async def test_specific_reference_found(self, handlers: _StubServer) -> None:
+        result = await handlers.read_handler("stata://skill/references/regression")
+        assert "Use ``regress``" in result
+
+    async def test_specific_reference_not_found_returns_placeholder(
+        self, handlers: _StubServer, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Topic miss → user-facing placeholder.  No WARNING-level noise for
+        what is typically a user-input typo; _read_reference already records
+        it at DEBUG level."""
+        with caplog.at_level(logging.WARNING):
+            result = await handlers.read_handler("stata://skill/references/no-such-topic")
+        assert "(reference not found: no-such-topic)" in result
+        # Must NOT escalate typical misses to WARNING — reserve that for
+        # real packaging/config problems (missing directory, I/O errors).
+        assert not any(rec.levelno >= logging.WARNING for rec in caplog.records)
+
+    async def test_unknown_uri_logs_error(
+        self, handlers: _StubServer, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown URIs are protocol violations → ERROR log + descriptive string."""
+        with caplog.at_level(logging.ERROR):
+            result = await handlers.read_handler("stata://bogus/path")
+        assert "(unknown resource: stata://bogus/path)" in result
+        assert any(
+            "Unknown MCP resource URI" in rec.message and rec.levelno == logging.ERROR
+            for rec in caplog.records
+        )


### PR DESCRIPTION
## Summary

Replace silent placeholder strings in the MCP resource helpers with structured WARNING/DEBUG/ERROR logs so operators can see packaging or deployment problems in their server log, without breaking the user-facing MCP resource-read contract.

## Motivation

`server.py` used to do things like:
```python
if not skill_path.is_file():
    return "(SKILL.md not found)"
```
and
```python
except (OSError, ValueError):
    pass  # Not all signals available on all platforms
```

Both patterns silently hide real configuration issues. A missing `SKILL.md` is usually a packaging mistake, not something a user should see as a cryptic placeholder in their chat.

## What changed

| Location | Before | After |
|---|---|---|
| `_read_skill_main()` | returned `"(SKILL.md not found)"` silently | WARNING log + same user-visible placeholder |
| `_list_reference_files()` | returned `[]` silently when dir missing | WARNING log when dir missing OR `glob()` OSError |
| `_read_reference()` | exact read then `glob()` for case-insensitive | exact read first (works on execute-only dirs); then list-based case-insensitive; DEBUG log for genuine topic miss |
| `handle_read_resource` unknown URI | silent `"(unknown resource: …)"` | ERROR log + same placeholder |
| Signal handler registration | `except …: pass` | `except … as exc: log.debug(…)` |

User-facing return values are unchanged — the MCP resource-read contract still returns a string in every branch. The only new signal is in the server log, which operators control via `MCP_STATA_LOGLEVEL`.

## Tests

16 new unit tests in `tests/test_server_resources.py` covering:
- Happy paths: file content returned, case-insensitive match, sorted list
- Missing file / missing directory
- `glob()` raises OSError (simulated via monkeypatched `Path.glob`)
- `read_text()` raises OSError
- Empty-but-valid directory (DEBUG fires, no false WARNING)
- Execute-only directory (exact-name read still succeeds even when `glob()` fails)
- All four branches of `handle_read_resource`: main, reference list, specific ref, unknown URI
- No-WARNING assertion for ordinary topic misses (avoids alert fatigue)

## Test plan

- [x] `uv sync --extra dev`
- [x] `uv run python -m pytest tests/test_server_resources.py tests/test_discovery.py` → 58 passed
- [x] `uv run ruff check src/stata_ai_fusion/server.py tests/test_server_resources.py` → clean
- [x] Three rounds of automated Codex code review; final verdict `READY-TO-COMMIT`
- [ ] Manual smoke: remove `skill/` and check server log shows WARNING about missing SKILL.md on first list/read

## Notes

- Pre-existing integration tests (`tests/test_integration.py`) need a real Stata installation and are unaffected.
- Line length ≤100 per project style; all new functions have docstrings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing or inaccessible SKILL documentation and reference files, displaying user-friendly error messages instead of failures.
  * Enhanced case-insensitive reference topic matching for more reliable lookups.

* **Tests**
  * Added comprehensive test coverage for resource handling and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->