### PR TITLE
Fix session persistence (no-PTY) + 6 diagnosed bugs

### DIFF
--- a/src/stata_ai_fusion/graph_cache.py
+++ b/src/stata_ai_fusion/graph_cache.py
@@ -197,15 +197,20 @@ class GraphCache:
 # ---------------------------------------------------------------------------
 
 # Patterns that indicate the Stata code produces graphical output.
-# We look for common graph commands at the start of a line (possibly after
-# whitespace or a `quietly` prefix).
+# Anchored with ``^`` under ``re.MULTILINE`` so that ``match.start()`` is the
+# start of the graph command's own line (NOT the preceding newline) — the
+# caller relies on that to compute the correct line index for insertion.
 _GRAPH_CMD_RE = re.compile(
     r"""
-    (?:^|\n)                     # start of string or new line
+    ^                            # start of a line (re.MULTILINE)
     [ \t]*                       # optional leading whitespace
     (?:qui(?:etly)?[ \t]+)?      # optional quietly prefix
     (?:
-        graph\b                  # graph (draw / twoway / …)
+        # `graph` and `graph <plottype>` draw, but the management
+        # subcommands below draw nothing — exclude them so we don't inject an
+        # export that errors ("no graph") or captures a stale/unrelated graph.
+        graph\b
+        (?![ \t]+(?:drop|dir|describe|rename|copy|query|close|set|save|export)\b)
       | tw(?:oway)?\b            # twoway shorthand
       | scatter\b                # scatter
       | line\b                   # line
@@ -221,7 +226,7 @@ _GRAPH_CMD_RE = re.compile(
       | coefplot\b               # coefplot (user-written but very common)
     )
     """,
-    re.VERBOSE,
+    re.VERBOSE | re.MULTILINE,
 )
 
 # Detects an existing graph export command anywhere in the code.
@@ -270,7 +275,9 @@ def maybe_inject_graph_export(code: str, tmpdir: Path) -> str:
     result_lines = list(lines)  # mutable copy
 
     for m in reversed(matches):
-        # Find which line number the match falls on.
+        # Which line the command starts on.  Because _GRAPH_CMD_RE is anchored
+        # with ``^`` (re.MULTILINE), m.start() is the start of the command's own
+        # line, so the count of preceding newlines is exactly its 0-based index.
         char_pos = m.start()
         line_idx = code[:char_pos].count("\n")
 

--- a/src/stata_ai_fusion/result_extractor.py
+++ b/src/stata_ai_fusion/result_extractor.py
@@ -59,6 +59,12 @@ _MATRIX_DIM_RE = re.compile(
     re.MULTILINE,
 )
 
+# A valid stored-result name is a plain Stata identifier.  Names that reach
+# get_scalar/get_matrix/get_macro are interpolated into executed Stata code,
+# so anything else is rejected to prevent command injection (e.g. a crafted
+# key like ``N)\nshell ...`` smuggled in through the get_results `keys` field).
+_RESULT_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 
 def _parse_numeric(value: str) -> float | None:
     """Parse a Stata numeric value to a Python float.
@@ -259,6 +265,20 @@ class ResultExtractor:
             raise ValueError(msg)
         return rc
 
+    @staticmethod
+    def _validate_result_name(name: str) -> str:
+        """Validate a stored-result *name* before interpolating it into Stata.
+
+        Stored-result names (scalars/macros/matrices in r()/e()/c()) are plain
+        Stata identifiers.  Rejecting anything else prevents a crafted name from
+        injecting extra Stata/OS commands.
+        """
+        cleaned = name.strip()
+        if not _RESULT_NAME_RE.match(cleaned):
+            msg = f"result name must be a Stata identifier, got {name!r}"
+            raise ValueError(msg)
+        return cleaned
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -288,6 +308,7 @@ class ResultExtractor:
         >>> value = await extractor.get_scalar("mean", "r")
         """
         rc = self._validate_result_class(result_class)
+        name = self._validate_result_name(name)
         code = f"display {rc}({name})"
         output = await self._execute(code)
         if output is None:
@@ -332,6 +353,7 @@ class ResultExtractor:
         >>> coeffs = await extractor.get_matrix("b", "e")
         """
         rc = self._validate_result_class(result_class)
+        name = self._validate_result_name(name)
         code = f"matrix list {rc}({name})"
         output = await self._execute(code)
         if output is None:
@@ -363,6 +385,7 @@ class ResultExtractor:
         >>> depvar = await extractor.get_macro("depvar", "e")
         """
         rc = self._validate_result_class(result_class)
+        name = self._validate_result_name(name)
         code = f"display {rc}({name})"
         output = await self._execute(code)
         if output is None:

--- a/src/stata_ai_fusion/stata_session.py
+++ b/src/stata_ai_fusion/stata_session.py
@@ -1,9 +1,12 @@
-"""Stata session management — interactive (pexpect) and batch fallback.
+"""Stata session management — interactive (pexpect), persistent pipe, and batch.
 
 Provides :class:`StataSession` for interactive Stata communication via
-``pexpect``, :class:`BatchSession` as a fallback when ``pexpect`` is not
-available, :class:`SessionManager` for managing multiple named sessions, and
-the :class:`ExecutionResult` dataclass that all execution methods return.
+``pexpect``, :class:`PipeSession` as a *stateful* fallback for hosts that deny
+PTY allocation (a single long-lived process driven over stdin, output read from
+a log file — state persists between calls), :class:`BatchSession` as the
+last-resort stateless fallback (a fresh process per call),
+:class:`SessionManager` for managing multiple named sessions, and the
+:class:`ExecutionResult` dataclass that all execution methods return.
 """
 
 from __future__ import annotations
@@ -111,19 +114,24 @@ def strip_smcl(text: str) -> str:
 # Error detection
 # ---------------------------------------------------------------------------
 
-ERROR_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"r\((\d+)\)"),  # standard error code r(111), r(198), etc.
-    re.compile(r"no observations", re.IGNORECASE),
-    re.compile(r"variable\s+.+\s+not found", re.IGNORECASE),
-    re.compile(r"type mismatch", re.IGNORECASE),
-    re.compile(r"conformability error", re.IGNORECASE),
-    re.compile(r"op\.sys refuses to", re.IGNORECASE),
-    re.compile(r"could not find file", re.IGNORECASE),
-    re.compile(r"no room to add more", re.IGNORECASE),
-]
+# Stata prints an error's return code as ``r(NNN);`` at the START of a line.
+# Anchoring (line start + trailing semicolon) is essential: the bare pattern
+# ``r\(\d+\)`` matched a return code merely *mentioned* in output/help text or a
+# comment — e.g. ``display "see r(198)"`` was wrongly reported as an error.
+_ERROR_CODE_RE = re.compile(r"(?m)^[ \t]*r\((\d+)\);")
 
-# Specific pattern for extracting numeric error codes: r(NNN)
-_ERROR_CODE_RE = re.compile(r"r\((\d+)\)")
+# Secondary patterns for the rare case where the ``r(NNN);`` line is absent from
+# the captured output (e.g. it was truncated).  Anchored to the start of a line
+# so the same words appearing mid-sentence in normal output do not misfire.
+_TEXT_ERROR_RES: list[re.Pattern[str]] = [
+    re.compile(r"^[ \t]*no observations\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^[ \t]*variable\s+\S+\s+not found\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^[ \t]*type mismatch\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^[ \t]*conformability error\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^[ \t]*op\.sys refuses to\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^[ \t]*could not find file\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^[ \t]*no room to add more\b", re.IGNORECASE | re.MULTILINE),
+]
 
 
 def _detect_error(output: str) -> tuple[str | None, int | None]:
@@ -135,29 +143,35 @@ def _detect_error(output: str) -> tuple[str | None, int | None]:
         ``(error_message, error_code)`` if an error is found, or
         ``(None, None)`` if the output looks clean.
     """
-    # First check for the standard r(NNN) error code.
+    # Primary, authoritative signal: an ``r(NNN);`` line that Stata emits when a
+    # command aborts.
     m = _ERROR_CODE_RE.search(output)
     if m:
         code = int(m.group(1))
-        # Try to extract the line preceding the error code as a message.
-        # Stata typically prints the error text on the line(s) before r(NNN).
-        lines = output.splitlines()
-        error_msg_parts: list[str] = []
-        for line in lines:
+        # The error text is the non-empty, non-echo line(s) immediately before
+        # the ``r(NNN);`` line.
+        parts: list[str] = []
+        for line in reversed(output[: m.start()].splitlines()):
             stripped = line.strip()
-            if _ERROR_CODE_RE.search(stripped):
+            if not stripped:
+                if parts:
+                    break  # blank line ends the message block
+                continue
+            # Stop at an echoed command (". cmd") or an earlier r(NNN); line.
+            if stripped.startswith(". ") or _ERROR_CODE_RE.search(line):
                 break
-            if stripped:
-                error_msg_parts.append(stripped)
-        tail = error_msg_parts[-3:] if len(error_msg_parts) > 3 else error_msg_parts
-        error_msg = "\n".join(tail) if tail else f"Stata error r({code})"
+            parts.append(stripped)
+            if len(parts) >= 2:
+                break
+        parts.reverse()
+        error_msg = "\n".join(parts) if parts else f"Stata error r({code})"
         return error_msg, code
 
-    # Check for other error patterns (no numeric code).
-    for pattern in ERROR_PATTERNS[1:]:
+    # Fallback: a recognised error phrase at the start of a line.
+    for pattern in _TEXT_ERROR_RES:
         pm = pattern.search(output)
         if pm:
-            return pm.group(0), None
+            return pm.group(0).strip(), None
 
     return None, None
 
@@ -273,20 +287,36 @@ class StataSession:
             self.installation,
         )
 
-        # Run pexpect spawn in a thread because it blocks.
-        self._process = await anyio.to_thread.run_sync(
-            self._spawn_process, abandon_on_cancel=True,
-        )
+        # Run the blocking pexpect spawn in a worker thread.  Do NOT abandon on
+        # cancel — that would leave the thread spawning Stata with no handle to
+        # kill.  _spawn_process assigns self._process *before* waiting for the
+        # prompt, so a process that launched but failed to initialise is still
+        # reachable (and killable) here.
+        try:
+            await anyio.to_thread.run_sync(self._spawn_process)
+        except BaseException:
+            # Startup failed (PTY denied, Stata crashed/timed out at boot) or was
+            # cancelled.  Kill whatever process did launch and remove the eagerly
+            # created temp dir so neither leaks (incl. on CancelledError, which is
+            # a BaseException — hence not 'except Exception').
+            self._kill_process()
+            _cleanup_temp_dir(self._tmpdir)
+            raise
         self._started = True
         log.info("Session %s started successfully", self.session_id)
 
-    def _spawn_process(self) -> pexpect.spawn:  # type: ignore[name-defined]
-        """Synchronous helper to spawn the Stata process."""
+    def _spawn_process(self) -> None:
+        """Spawn Stata and drive it to the first prompt.
+
+        Assigns ``self._process`` to the spawned child *before* waiting for the
+        prompt, so a process that launched but then failed (or was cancelled)
+        mid-initialisation is still reachable for cleanup by :meth:`start`.
+        """
         stata_path = str(self.installation.path)
 
         # Start Stata in interactive (console) mode.
         # -q suppresses the startup banner for cleaner output parsing.
-        child = pexpect.spawn(
+        self._process = pexpect.spawn(
             stata_path,
             args=["-q"],
             cwd=str(self._tmpdir),
@@ -297,14 +327,12 @@ class StataSession:
         )
 
         # Wait for the initial prompt.
-        child.expect(r"\. $", timeout=_START_TIMEOUT)
+        self._process.expect(r"\. $", timeout=_START_TIMEOUT)
 
         # Disable GUI graph windows so Stata never blocks waiting for
         # user interaction in the background.
-        child.sendline("set graphics off")
-        child.expect(r"\. $", timeout=_START_TIMEOUT)
-
-        return child
+        self._process.sendline("set graphics off")
+        self._process.expect(r"\. $", timeout=_START_TIMEOUT)
 
     async def close(self) -> None:
         """Close the Stata process and clean up resources.
@@ -866,6 +894,460 @@ class BatchSession:
 
 
 # ---------------------------------------------------------------------------
+# PipeSession (persistent fallback when a PTY cannot be allocated)
+# ---------------------------------------------------------------------------
+
+
+class PipeSession:
+    """Persistent Stata session driven over stdin, with output read from a log.
+
+    This is the preferred fallback when an interactive :class:`StataSession`
+    cannot be created because the host denies PTY allocation (e.g. sandboxed
+    launches where ``openpty`` raises ``PermissionError``), but a long-running
+    child process is still allowed.
+
+    Unlike :class:`BatchSession` — which starts a fresh ``stata -b`` process
+    per call and therefore loses all in-memory state between calls — this keeps
+    a *single* Stata process alive, so data, locals, scalars, matrices,
+    programs and ``e()``/``r()`` results persist between tool calls, matching
+    the behaviour users expect from an interactive session.
+
+    How it works:
+
+    1. ``stata -q`` is spawned with stdin connected to a pipe and stdout/stderr
+       discarded.
+    2. A named text *log* is opened in the session temp dir.  Stata
+       block-buffers a piped stdout, but it flushes its log file promptly, so
+       output is read from the **log file**, never the pipe.
+    3. Each :meth:`execute` writes the code to a temporary ``.do`` file and
+       sends ``do "<file>"`` bracketed by unique sentinel ``display`` commands.
+       The call is complete once the closing sentinel appears in the log; the
+       captured region is everything between the sentinels.  Running via ``do``
+       (rather than feeding lines interactively) preserves do-file semantics:
+       ``#delimit``, ``///`` continuation, comments, and error-aborts-the-file.
+    """
+
+    # Polling interval (seconds) when tailing the log file for completion.
+    _POLL_INTERVAL = 0.05
+
+    def __init__(
+        self,
+        installation: StataInstallation,
+        session_id: str = "default",
+    ) -> None:
+        self.installation = installation
+        self.session_id = session_id
+        self._lock: anyio.Lock = anyio.Lock()
+        self._tmpdir: Path = _make_temp_dir()
+        self._graph_cache: GraphCache = GraphCache(self._tmpdir)
+        self._log_buffer: list[str] = []
+        self._started: bool = False
+        self._process: subprocess.Popen | None = None
+        # Process-group id, captured at spawn while the child is guaranteed
+        # alive.  Signalling this cached value avoids calling os.getpgid()
+        # after the lead process may have been reaped (which would race with
+        # the worker thread's proc.poll()).
+        self._pgid: int | None = None
+        self._log_file: Path = self._tmpdir / "_session.log"
+
+    @staticmethod
+    def _stata_quote(path: Path) -> str:
+        """Wrap *path* in Stata compound double quotes (`"..."').
+
+        Compound quotes let the path contain a literal ``"`` without breaking
+        the surrounding string.  (They do NOT suppress ``$``/backtick macro
+        expansion — but session temp dirs come from ``tempfile.mkdtemp`` and do
+        not contain those.)
+        """
+        return '`"' + str(path) + '"\''
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Spawn the persistent Stata process and wait until it is ready."""
+        try:
+            await anyio.to_thread.run_sync(self._start_sync)
+        except BaseException:
+            # Startup failed, or was cancelled AFTER the worker thread already
+            # spawned Stata (to_thread does not abandon the thread, so the
+            # process can be live even though we were cancelled).  Kill it and
+            # remove the eagerly-created temp dir so neither leaks, regardless
+            # of which caller invoked start().
+            self._kill_process()
+            _cleanup_temp_dir(self._tmpdir)
+            raise
+        self._started = True
+        log.info("PipeSession %s started (persistent pipe mode)", self.session_id)
+
+    def _start_sync(self) -> None:
+        stata_path = str(self.installation.path)
+        try:
+            self._process = subprocess.Popen(
+                [stata_path, "-q"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                cwd=str(self._tmpdir),
+                start_new_session=True,
+                text=True,
+                env={**os.environ, "TERM": "dumb"},
+            )
+            # start_new_session=True makes the child its own process-group
+            # leader, so pgid == pid.  Capture it now while the child is alive.
+            self._pgid = os.getpgid(self._process.pid)
+            # Disable pagination (otherwise long output blocks forever waiting
+            # on a "--more--" prompt nobody can answer), suppress GUI graph
+            # windows, and open the capture log under a *named* log so it does
+            # not collide with the user's own (unnamed) `log using` / `log
+            # close` / `capture log close` usage inside their do-files.
+            self._write_lines(
+                "set more off",
+                "set graphics off",
+                f"log using {self._stata_quote(self._log_file)}, replace text name(_saf_capture)",
+            )
+            # Confirm the process booted and the log is live before returning.
+            self._write_lines('display "<<<SAF_READY>>>"')
+            deadline = time.monotonic() + _START_TIMEOUT
+            while time.monotonic() < deadline:
+                if self._process.poll() is not None:
+                    raise RuntimeError(
+                        f"Stata exited during startup (code {self._process.returncode})"
+                    )
+                if "<<<SAF_READY>>>" in self._read_log_text():
+                    return
+                time.sleep(self._POLL_INTERVAL)
+            raise TimeoutError("Stata pipe session did not become ready in time")
+        except Exception:
+            self._kill_process()
+            raise
+
+    def _write_lines(self, *lines: str) -> None:
+        """Write one or more command lines to the child's stdin."""
+        proc = self._process
+        if proc is None or proc.stdin is None:
+            raise BrokenPipeError("Stata process stdin is not available")
+        proc.stdin.write("".join(f"{line}\n" for line in lines))
+        proc.stdin.flush()
+
+    def _read_log_text(self) -> str:
+        """Read the entire capture log as decoded text (best effort)."""
+        try:
+            with open(self._log_file, "rb") as fh:
+                return fh.read().decode("utf-8", errors="replace")
+        except OSError:
+            return ""
+
+    def _log_size(self) -> int:
+        """Return the current byte size of the capture log (0 if missing)."""
+        try:
+            return self._log_file.stat().st_size
+        except OSError:
+            return 0
+
+    @property
+    def is_alive(self) -> bool:
+        return (
+            self._started
+            and self._process is not None
+            and self._process.poll() is None
+        )
+
+    @property
+    def tmpdir(self) -> Path:
+        """Return the session's temporary directory."""
+        return self._tmpdir
+
+    async def close(self) -> None:
+        """Shut down the Stata process and clean up the temporary directory."""
+        self._started = False
+        await anyio.to_thread.run_sync(self._close_sync)
+        _cleanup_temp_dir(self._tmpdir)
+        log.info("PipeSession %s closed", self.session_id)
+
+    def _close_sync(self) -> None:
+        proc = self._process
+        self._process = None
+        if proc is None:
+            return
+        try:
+            if proc.stdin is not None and not proc.stdin.closed:
+                try:
+                    proc.stdin.write("log close _all\nexit, clear\n")
+                    proc.stdin.flush()
+                except (BrokenPipeError, OSError, ValueError):
+                    pass
+                try:
+                    proc.stdin.close()
+                except OSError:
+                    pass
+            try:
+                proc.wait(timeout=5)
+                return
+            except subprocess.TimeoutExpired:
+                pass
+        except Exception:
+            log.debug("Error during PipeSession graceful close", exc_info=True)
+        self._kill_group(proc)
+
+    def _kill_process(self) -> None:
+        """Force-kill the process group and reset state."""
+        proc = self._process
+        self._process = None
+        self._started = False
+        if proc is not None:
+            self._kill_group(proc)
+        self._pgid = None
+
+    def _kill_group(self, proc: subprocess.Popen) -> None:
+        """SIGKILL the whole process group (incl. Stata-MP workers), then reap.
+
+        Uses the pgid captured at spawn rather than ``os.getpgid(proc.pid)``,
+        which would fail (or race) once the lead process has been reaped.
+        """
+        pgid = self._pgid
+        try:
+            if pgid is not None:
+                os.killpg(pgid, signal.SIGKILL)
+            else:
+                proc.kill()
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.kill()
+            except OSError:
+                pass
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+
+    def send_interrupt(self) -> bool:
+        """Send SIGINT to the Stata process group to abort the running command.
+
+        Unlike :class:`BatchSession`, a persistent process *can* be
+        interrupted, so this returns ``True`` when the signal is delivered.
+        Stata aborts the current command and returns to its prompt; the
+        session and the data in memory are preserved.
+
+        Signals the pgid captured at spawn (never ``os.getpgid`` here), so it
+        is safe to call from the event loop while a worker thread tails the
+        log — it does not touch the (non-thread-safe) ``proc`` object.
+        """
+        pgid = self._pgid
+        if self._process is not None and pgid is not None:
+            try:
+                os.killpg(pgid, signal.SIGINT)
+                log.info("Sent interrupt to PipeSession %s", self.session_id)
+                return True
+            except (ProcessLookupError, PermissionError, OSError):
+                log.warning(
+                    "Failed to interrupt PipeSession %s", self.session_id, exc_info=True
+                )
+        return False
+
+    async def _ensure_alive(self) -> None:
+        """Restart the process if it has died (in-memory state is then lost)."""
+        if not self.is_alive:
+            if self._started:
+                log.warning(
+                    "PipeSession %s process died; restarting (in-memory state lost)",
+                    self.session_id,
+                )
+            self._kill_process()
+            if not self._tmpdir.exists():
+                self._tmpdir = _make_temp_dir()
+                self._graph_cache = GraphCache(self._tmpdir)
+            self._log_file = self._tmpdir / "_session.log"
+            await self.start()
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    async def execute(self, code: str, timeout: int = _DEFAULT_TIMEOUT) -> ExecutionResult:
+        """Execute Stata code in the persistent session and return the result.
+
+        A per-session async lock serializes concurrent calls so only one
+        command runs against the shared process at a time.
+        """
+        async with self._lock:
+            await self._ensure_alive()
+
+            # Inject graph export if the code draws a graph but has no export.
+            code = maybe_inject_graph_export(code, self._tmpdir)
+
+            # Snapshot graph files before execution.
+            self._graph_cache.take_snapshot()
+
+            start_time = time.monotonic()
+
+            marker = uuid.uuid4().hex[:12]
+            start_s = f"<<<SAF_S_{marker}>>>"
+            end_s = f"<<<SAF_E_{marker}>>>"
+            do_file = self._tmpdir / f"_cmd_{marker}.do"
+            do_file.write_text(code, encoding="utf-8")
+
+            try:
+                raw = await anyio.to_thread.run_sync(
+                    lambda: self._run_and_capture(do_file, start_s, end_s, timeout),
+                    # Do NOT abandon on cancel: the lock protects the shared
+                    # process, and the deadline in _run_and_capture bounds the
+                    # wait.  Abandoning would release the lock with a thread
+                    # still tailing the log.
+                )
+            except TimeoutError:
+                elapsed = time.monotonic() - start_time
+                # Abort the stuck command but keep the session (and its data).
+                self.send_interrupt()
+                hint = (
+                    f"Command timed out after {timeout}s. The running command was "
+                    "interrupted; the session and data in memory are preserved.\n"
+                    "  • Increase the timeout parameter, or\n"
+                    "  • use the run_do_file tool for long-running models."
+                )
+                return ExecutionResult(
+                    output=hint,
+                    return_code=1,
+                    error_message=hint,
+                    error_code=None,
+                    graphs=[],
+                    execution_time=elapsed,
+                    log_path=self._log_file if self._log_file.exists() else None,
+                )
+            except (BrokenPipeError, OSError, ValueError) as exc:
+                elapsed = time.monotonic() - start_time
+                self._kill_process()
+                return ExecutionResult(
+                    output="",
+                    return_code=1,
+                    error_message=f"Stata process terminated unexpectedly: {exc}",
+                    error_code=None,
+                    graphs=[],
+                    execution_time=elapsed,
+                    log_path=None,
+                )
+            finally:
+                try:
+                    do_file.unlink(missing_ok=True)
+                except OSError:
+                    log.debug("Failed to remove temp do-file %s", do_file)
+
+            elapsed = time.monotonic() - start_time
+
+            # Strip SMCL, then reuse StataSession's do-output cleaner (same
+            # echo/`end of do-file` stripping the interactive path uses).
+            cleaned = strip_smcl(raw)
+            cleaned = StataSession._clean_do_output(cleaned, do_file)
+
+            error_message, error_code = _detect_error(cleaned)
+            return_code = 0 if error_code is None and error_message is None else 1
+
+            graphs = self._graph_cache.detect_changes()
+
+            self._log_buffer.append(cleaned)
+            if len(self._log_buffer) > _MAX_LOG_BUFFER_ENTRIES:
+                self._log_buffer = self._log_buffer[-_MAX_LOG_BUFFER_ENTRIES:]
+
+            log.debug(
+                "PipeSession %s execute completed in %.2fs (rc=%d, graphs=%d)",
+                self.session_id,
+                elapsed,
+                return_code,
+                len(graphs),
+            )
+
+            return ExecutionResult(
+                output=cleaned,
+                return_code=return_code,
+                error_message=error_message,
+                error_code=error_code,
+                graphs=graphs,
+                execution_time=elapsed,
+                log_path=self._log_file if self._log_file.exists() else None,
+            )
+
+    def _run_and_capture(
+        self, do_file: Path, start_s: str, end_s: str, timeout: int
+    ) -> str:
+        """Send the bracketed ``do`` and tail the log until the end sentinel.
+
+        Runs in a worker thread.  Raises :class:`TimeoutError` if the closing
+        sentinel does not appear within *timeout* seconds, or
+        :class:`BrokenPipeError` if the process exits first.
+        """
+        proc = self._process
+        if proc is None or proc.stdin is None:
+            raise BrokenPipeError("Stata process is not running")
+
+        offset = self._log_size()
+        # Re-assert `set more off` before each command (it is session-global
+        # mutable state a prior command could have flipped back on, which would
+        # otherwise block on a "--more--" prompt).  It precedes the opening
+        # sentinel, so it never appears in the captured region.
+        self._write_lines(
+            "set more off",
+            f'display "{start_s}"',
+            f"do {self._stata_quote(do_file)}",
+            f'display "{end_s}"',
+        )
+
+        end_bytes = end_s.encode("utf-8")
+        deadline = time.monotonic() + timeout
+        buf = b""
+        with open(self._log_file, "rb") as fh:
+            fh.seek(offset)
+            while True:
+                chunk = fh.read()
+                if chunk:
+                    buf += chunk
+                    if end_bytes in buf:
+                        break
+                    continue
+                if proc.poll() is not None:
+                    raise BrokenPipeError(
+                        f"Stata exited unexpectedly (code {proc.returncode})"
+                    )
+                if time.monotonic() > deadline:
+                    raise TimeoutError(f"Total execution timeout exceeded ({timeout}s)")
+                time.sleep(self._POLL_INTERVAL)
+
+        return self._extract_region(buf.decode("utf-8", errors="replace"), start_s, end_s)
+
+    @staticmethod
+    def _extract_region(text: str, start_s: str, end_s: str) -> str:
+        """Return the log text strictly between the two sentinels.
+
+        Boundaries are the opening sentinel's *value* line (its last
+        occurrence) and the closing sentinel's *command-echo* line (its first
+        occurrence), so the sentinel lines themselves are excluded.
+        """
+        s = text.rfind(start_s)
+        if s == -1:
+            region_start = 0
+        else:
+            nl = text.find("\n", s)
+            region_start = nl + 1 if nl != -1 else len(text)
+        e = text.find(end_s)
+        if e == -1:
+            region_end = len(text)
+        else:
+            ls = text.rfind("\n", 0, e)
+            region_end = ls if ls != -1 else 0
+        if region_end < region_start:
+            return ""
+        return text[region_start:region_end]
+
+    # ------------------------------------------------------------------
+    # Log access
+    # ------------------------------------------------------------------
+
+    def get_log(self) -> str:
+        """Return the accumulated session log."""
+        return "\n".join(self._log_buffer)
+
+
+# ---------------------------------------------------------------------------
 # SessionManager
 # ---------------------------------------------------------------------------
 
@@ -893,7 +1375,7 @@ class SessionManager:
         use_batch: bool | None = None,
         session_timeout: int = 3600,
     ) -> None:
-        self._sessions: dict[str, StataSession | BatchSession] = {}
+        self._sessions: dict[str, StataSession | BatchSession | PipeSession] = {}
         self._lock: anyio.Lock = anyio.Lock()
         self.installation = installation
         self._session_timeout = session_timeout
@@ -902,6 +1384,18 @@ class SessionManager:
             self._use_batch = not HAS_PEXPECT
         else:
             self._use_batch = use_batch
+        # Set once an interactive PTY is found to be unavailable but a
+        # persistent pipe session works — avoids retrying pexpect every time.
+        self._use_pipe = False
+        # session_id -> Event, marking a creation in progress.  Lets concurrent
+        # callers for the same id wait instead of double-creating, while the
+        # (slow) start() runs OUTSIDE the manager lock.
+        self._creating: dict[str, anyio.Event] = {}
+        # Bumped by close_all()/close_session().  A creator that ran start()
+        # outside the lock checks this before publishing: if it changed, a
+        # concurrent close raced the creation, so the new session is closed
+        # instead of stored (otherwise a live Stata process would be orphaned).
+        self._generation = 0
 
     # ------------------------------------------------------------------
     # Public API
@@ -910,7 +1404,7 @@ class SessionManager:
     async def get_or_create(
         self,
         session_id: str = "default",
-    ) -> StataSession | BatchSession:
+    ) -> StataSession | BatchSession | PipeSession:
         """Return an existing session or create and start a new one.
 
         A manager-level lock prevents TOCTOU races where concurrent
@@ -923,71 +1417,169 @@ class SessionManager:
 
         Returns
         -------
-        StataSession | BatchSession
+        StataSession | BatchSession | PipeSession
         """
-        async with self._lock:
-            # Expire idle sessions.
-            now = time.monotonic()
-            expired = [
-                sid for sid, last in self._last_activity.items()
-                if now - last > self._session_timeout and sid in self._sessions
-            ]
-            for sid in expired:
-                stale = self._sessions.pop(sid)
-                self._last_activity.pop(sid, None)
-                log.info("Session %s expired after %ds idle", sid, self._session_timeout)
-                try:
-                    await stale.close()
-                except Exception:
-                    log.warning("Error closing expired session %s", sid, exc_info=True)
+        while True:
+            to_close: list[tuple[str, StataSession | BatchSession | PipeSession]] = []
+            wait_event: anyio.Event | None = None
+            creator = False
+            gen_at_start = 0
+            result: StataSession | BatchSession | PipeSession | None = None
 
-            if session_id in self._sessions:
-                session = self._sessions[session_id]
-                # Auto-restart if dead.
-                if not session.is_alive:
-                    log.warning(
-                        "Session %s is dead; removing and re-creating",
-                        session_id,
-                    )
-                    del self._sessions[session_id]
+            async with self._lock:
+                # Collect idle/dead sessions to close *after* releasing the lock
+                # (closing can block for seconds; holding the lock would stall
+                # every other manager operation, incl. the cancel tool).
+                now = time.monotonic()
+                for sid in [
+                    s
+                    for s, last in self._last_activity.items()
+                    if now - last > self._session_timeout and s in self._sessions
+                ]:
+                    to_close.append((sid, self._sessions.pop(sid)))
+                    self._last_activity.pop(sid, None)
+                    log.info("Session %s expired after %ds idle", sid, self._session_timeout)
+
+                existing = self._sessions.get(session_id)
+                if existing is not None and not existing.is_alive:
+                    log.warning("Session %s is dead; removing and re-creating", session_id)
+                    to_close.append((session_id, self._sessions.pop(session_id)))
                     self._last_activity.pop(session_id, None)
-                else:
-                    self._last_activity[session_id] = time.monotonic()
-                    return session
+                    existing = None
 
-            log.info(
-                "Creating new %s session: %s",
-                "batch" if self._use_batch else "interactive",
+                if existing is not None:
+                    self._last_activity[session_id] = time.monotonic()
+                    result = existing
+                elif session_id in self._creating:
+                    # Another caller is already starting this id — wait for it.
+                    wait_event = self._creating[session_id]
+                else:
+                    # We will create it; publish an event so concurrent callers
+                    # wait rather than double-create.
+                    self._creating[session_id] = anyio.Event()
+                    creator = True
+                    gen_at_start = self._generation
+
+            # ---- outside the manager lock ----
+            if not creator:
+                # Cache hit, or another caller is creating this id.
+                await self._close_sessions(to_close)
+                if result is not None:
+                    return result
+                assert wait_event is not None
+                await wait_event.wait()
+                continue
+
+            # We are the creator.  From here self._creating[session_id] is
+            # registered: its Event MUST be popped+set on EVERY exit (return,
+            # exception, cancellation) or waiters block forever.  The bookkeeping
+            # runs in a cancellation-shielded scope because acquiring the lock is
+            # itself a cancellation checkpoint.
+            session: StataSession | BatchSession | PipeSession | None = None
+            raced_close = False
+            try:
+                await self._close_sessions(to_close)
+                session = await self._create_started_session(session_id)
+            finally:
+                with anyio.CancelScope(shield=True):
+                    async with self._lock:
+                        ev = self._creating.pop(session_id, None)
+                        if self._generation != gen_at_start:
+                            # A close_all()/close_session() ran while we were
+                            # creating outside the lock.  Do NOT store, or a live
+                            # Stata process the close() never saw would orphan.
+                            raced_close = True
+                        elif session is not None:
+                            self._sessions[session_id] = session
+                            self._last_activity[session_id] = time.monotonic()
+                    if ev is not None:
+                        ev.set()
+                    if raced_close and session is not None:
+                        try:
+                            await session.close()
+                        except Exception:
+                            log.warning(
+                                "Error closing raced session %s", session_id, exc_info=True
+                            )
+                        session = None
+
+            if raced_close:
+                # A concurrent close won the race; re-evaluate from scratch.
+                continue
+            return session
+
+    async def _close_sessions(
+        self, sessions: list[tuple[str, StataSession | BatchSession | PipeSession]]
+    ) -> None:
+        """Close the given (id, session) pairs, logging but not raising."""
+        for sid, session in sessions:
+            try:
+                await session.close()
+            except Exception:
+                log.warning("Error closing session %s", sid, exc_info=True)
+
+    async def _create_started_session(
+        self, session_id: str
+    ) -> StataSession | BatchSession | PipeSession:
+        """Create and start a session in the active mode, with fallback.
+
+        Runs *outside* the manager lock so a slow Stata boot never blocks other
+        manager operations (``get_session`` — used by the cancel tool —
+        ``close_session``, ``list_sessions``, and other creations).
+        """
+        mode = "batch" if self._use_batch else "pipe" if self._use_pipe else "interactive"
+        log.info("Creating new %s session: %s", mode, session_id)
+
+        if self._use_batch:
+            session: StataSession | BatchSession | PipeSession = BatchSession(
+                self.installation, session_id=session_id
+            )
+            await session.start()
+            return session
+        if self._use_pipe:
+            session = PipeSession(self.installation, session_id=session_id)
+            await session.start()
+            return session
+
+        session = StataSession(self.installation, session_id=session_id)
+        try:
+            await session.start()
+            return session
+        except PermissionError:
+            # macOS / sandboxed launches may deny PTY creation.  StataSession.start()
+            # has already killed any process and removed its own temp dir, so we just
+            # fall back to a *persistent pipe* session (state still persists between
+            # calls); only if that also fails do we drop to stateless batch.
+            log.warning(
+                "Interactive PTY denied for session %s; trying persistent pipe mode",
                 session_id,
             )
 
-            session: StataSession | BatchSession
-            if self._use_batch:
-                session = BatchSession(self.installation, session_id=session_id)
-                await session.start()
-            else:
-                session = StataSession(self.installation, session_id=session_id)
-                try:
-                    await session.start()
-                except PermissionError:
-                    # macOS may deny PTY creation if the host app lacks
-                    # "Developer Tools" entitlements.  Fall back to batch
-                    # mode so the MCP server stays functional.
-                    log.warning(
-                        "Interactive session failed (PermissionError); "
-                        "falling back to batch mode for session %s",
-                        session_id,
-                    )
-                    _cleanup_temp_dir(session._tmpdir)
-                    session = BatchSession(self.installation, session_id=session_id)
-                    await session.start()
-                    self._use_batch = True  # avoid retrying pexpect
-
-            self._sessions[session_id] = session
-            self._last_activity[session_id] = time.monotonic()
+        try:
+            session = PipeSession(self.installation, session_id=session_id)
+            await session.start()
+            self._use_pipe = True  # avoid retrying pexpect for later sessions
+            log.info(
+                "Using persistent pipe-mode sessions: state persists between "
+                "calls without a PTY"
+            )
+            return session
+        except Exception as exc:
+            # PipeSession.start() already removed its own temp dir on failure.
+            log.warning(
+                "Pipe mode failed (%s); falling back to stateless batch mode for "
+                "session %s",
+                exc,
+                session_id,
+            )
+            session = BatchSession(self.installation, session_id=session_id)
+            await session.start()
+            self._use_batch = True
             return session
 
-    async def get_session(self, session_id: str) -> StataSession | BatchSession | None:
+    async def get_session(
+        self, session_id: str
+    ) -> StataSession | BatchSession | PipeSession | None:
         """Return an existing session without creating a new one.
 
         Returns ``None`` if the session does not exist.  This is safe to
@@ -1005,6 +1597,9 @@ class SessionManager:
         async with self._lock:
             session = self._sessions.pop(session_id, None)
             self._last_activity.pop(session_id, None)
+            # Signal any in-flight creator (running start() outside the lock)
+            # that a close raced it, so it discards rather than orphans.
+            self._generation += 1
         if session is not None:
             await session.close()
             log.info("Session %s closed and removed", session_id)
@@ -1019,11 +1614,17 @@ class SessionManager:
             snapshot = list(self._sessions.items())
         result: list[dict] = []
         for sid, session in snapshot:
+            if isinstance(session, BatchSession):
+                session_type = "batch"
+            elif isinstance(session, PipeSession):
+                session_type = "pipe"
+            else:
+                session_type = "interactive"
             result.append(
                 {
                     "session_id": sid,
                     "alive": session.is_alive,
-                    "type": "batch" if isinstance(session, BatchSession) else "interactive",
+                    "type": session_type,
                 }
             )
         return result
@@ -1034,6 +1635,9 @@ class SessionManager:
             sessions_to_close = dict(self._sessions)
             self._sessions.clear()
             self._last_activity.clear()
+            # Signal in-flight creators (running start() outside the lock) that
+            # a close raced them, so the new session is discarded, not orphaned.
+            self._generation += 1
 
         for sid, session in sessions_to_close.items():
             try:

--- a/src/stata_ai_fusion/tools/install_package.py
+++ b/src/stata_ai_fusion/tools/install_package.py
@@ -49,6 +49,24 @@ TOOL_DEF = Tool(
     },
 )
 
+# Marker used to surface `which`'s return code.  `capture` suppresses which's
+# own output (including the "not found" message and r(111)), so the only
+# reliable signal of whether a package exists is `_rc`, which we print and parse.
+_RC_MARKER = "__stata_pkg_rc="
+_RC_RE = re.compile(rf"{re.escape(_RC_MARKER)}(-?\d+)")
+
+
+def _parse_check_rc(output: str | None) -> int | None:
+    """Return the `_rc` from a ``which`` check, or ``None`` if not found.
+
+    A non-zero (e.g. 111) value means the command is not installed; ``0`` means
+    it is available; ``None`` means the marker was missing (treat as unknown).
+    """
+    if not output:
+        return None
+    m = _RC_RE.search(output)
+    return int(m.group(1)) if m else None
+
 
 async def handle(
     session_manager: SessionManager,
@@ -80,25 +98,30 @@ async def handle(
         log.error("Failed to get/create session %s: %s", session_id, exc)
         return [TextContent(type="text", text=f"Error creating session: {exc}")]
 
-    # Step 1: Check if already installed
-    check_code = f"capture which {package}"
+    # Step 1: Check whether the package is already installed.
+    #
+    # `which <pkg>` sets _rc=111 when the command is not found.  `capture`
+    # suppresses which's output, so we print _rc and read it back rather than
+    # scraping the (now-empty) text.  The previous implementation scraped the
+    # suppressed output and concluded EVERY missing package was "already
+    # installed", so it never actually installed anything.
+    check_code = f'capture which {package}\ndisplay "{_RC_MARKER}" _rc'
     try:
         check_result = await session.execute(check_code, timeout=30)
     except Exception as exc:
         log.error("Error checking package %s: %s", package, exc)
         return [TextContent(type="text", text=f"Error checking package: {exc}")]
 
-    # If `which` succeeds without error, the package is already installed
-    if check_result.return_code == 0 and check_result.error_message is None:
-        output = check_result.output or ""
-        # `which` prints the path when found; check it does not contain "not found"
-        if "not found" not in output.lower():
-            return [
-                TextContent(
-                    type="text",
-                    text=f"Package '{package}' is already installed.\n{output.strip()}",
-                )
-            ]
+    check_rc = _parse_check_rc(check_result.output)
+    if check_rc == 0:
+        return [
+            TextContent(
+                type="text",
+                text=f"Package '{package}' is already installed.",
+            )
+        ]
+    # check_rc is non-zero (not installed) or None (marker missing / unknown);
+    # fall through and attempt the install — `, replace` makes it idempotent.
 
     # Step 2: Install the package
     if from_ssc:

--- a/src/stata_ai_fusion/tools/run_command.py
+++ b/src/stata_ai_fusion/tools/run_command.py
@@ -35,11 +35,6 @@ TOOL_DEF = Tool(
                 "type": "string",
                 "description": "Stata commands to execute (may span multiple lines).",
             },
-            "echo": {
-                "type": "boolean",
-                "description": "Whether to echo commands in output. Default true.",
-                "default": True,
-            },
             "session_id": {
                 "type": "string",
                 "description": "Session identifier. Default 'default'.",
@@ -62,7 +57,6 @@ async def handle(
 ) -> list[TextContent | ImageContent]:
     """Execute Stata commands and return content blocks."""
     code: str = arguments.get("code", "")
-    echo: bool = arguments.get("echo", True)
     session_id: str = arguments.get("session_id", "default")
     timeout: int = max(1, min(int(arguments.get("timeout", 120)), 3600))
 
@@ -74,9 +68,6 @@ async def handle(
     except Exception as exc:
         log.error("Failed to get/create session %s: %s", session_id, exc)
         return [TextContent(type="text", text=f"Error creating session: {exc}")]
-
-    if not echo:
-        code = f"set output inform\n{code}"
 
     try:
         result = await session.execute(code, timeout=timeout)

--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -1,0 +1,110 @@
+"""Unit tests for Stata error detection and the run_command echo fix.
+
+Both are pure-logic tests that do not require a Stata installation.
+"""
+
+from __future__ import annotations
+
+from stata_ai_fusion.stata_session import ExecutionResult, _detect_error
+from stata_ai_fusion.tools.run_command import handle
+
+
+# ---------------------------------------------------------------------------
+# _detect_error: anchored r(NNN); detection (no false positives)
+# ---------------------------------------------------------------------------
+
+
+def test_no_false_positive_on_code_in_text():
+    """A return code merely mentioned in output text is NOT an error."""
+    msg, code = _detect_error("this mentions r(198) in text")
+    assert (msg, code) == (None, None)
+
+
+def test_no_false_positive_on_comment():
+    msg, code = _detect_error("* remember to check r(198) for syntax\n  price | 74")
+    assert (msg, code) == (None, None)
+
+
+def test_real_error_detected():
+    msg, code = _detect_error("command foo is unrecognized\nr(199);")
+    assert code == 199
+    assert msg == "command foo is unrecognized"
+
+
+def test_real_error_with_message_line():
+    msg, code = _detect_error("no variables defined\nr(111);")
+    assert code == 111
+    assert msg == "no variables defined"
+
+
+def test_duplicate_rc_line_batch_artifact():
+    """Batch output can repeat the r(NNN); line; detect the first cleanly."""
+    msg, code = _detect_error("command foo is unrecognized\nr(199);\n\n\nr(199);")
+    assert code == 199
+    assert msg == "command foo is unrecognized"
+
+
+def test_leading_whitespace_before_rc():
+    msg, code = _detect_error("    bad thing happened\n    r(111);")
+    assert code == 111
+
+
+def test_message_skips_command_echo():
+    out = ". summarize nope\nvariable nope not found\nr(111);"
+    msg, code = _detect_error(out)
+    assert code == 111
+    assert msg == "variable nope not found"  # the ". summarize nope" echo is skipped
+
+
+def test_clean_output_no_error():
+    out = ". summarize price\n    Variable | Obs Mean\n       price | 74  6165"
+    assert _detect_error(out) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# _detect_error: anchored text fallbacks
+# ---------------------------------------------------------------------------
+
+
+def test_text_fallback_at_line_start():
+    msg, code = _detect_error("no observations")
+    assert code is None
+    assert msg == "no observations"
+
+
+def test_text_fallback_not_midsentence():
+    """The same words mid-sentence must not trigger a false error."""
+    assert _detect_error("there were no observations dropped today") == (None, None)
+    assert _detect_error('display "type mismatch is a common error"') == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# run_command: the broken `set output inform` injection is gone
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def execute(self, code: str, timeout: int = 120) -> ExecutionResult:
+        self.calls.append(code)
+        return ExecutionResult(output="2", return_code=0)
+
+
+class _FakeManager:
+    def __init__(self, session: _FakeSession) -> None:
+        self._session = session
+
+    async def get_or_create(self, session_id: str) -> _FakeSession:
+        return self._session
+
+
+async def test_run_command_never_injects_set_output_inform():
+    """Even if a client still passes the removed `echo` arg, the code must run
+    verbatim — no `set output inform` that would suppress results / poison the
+    session."""
+    sess = _FakeSession()
+    await handle(_FakeManager(sess), {"code": "display 1+1", "echo": False})
+    assert sess.calls == ["display 1+1"]
+    assert all("set output inform" not in c for c in sess.calls)

--- a/tests/test_graph_cache.py
+++ b/tests/test_graph_cache.py
@@ -1,0 +1,73 @@
+"""Unit tests for graph auto-export injection (no Stata required)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from stata_ai_fusion.graph_cache import maybe_inject_graph_export
+
+TMP = Path("/tmp")
+
+
+def _export_indices(out: str) -> list[int]:
+    return [
+        i
+        for i, line in enumerate(out.split("\n"))
+        if "graph export" in line and "stata_graph_" in line
+    ]
+
+
+def test_export_after_graph_on_second_line():
+    """Regression: the export must follow a graph command that is not on the
+    first line.  Previously an off-by-one inserted it BEFORE the command, so
+    Stata raised r(601) ("no Graph window open") and no image was produced."""
+    out = maybe_inject_graph_export(
+        "sysuse auto, clear\nscatter price mpg\nsummarize price", TMP
+    ).split("\n")
+    assert out[0] == "sysuse auto, clear"
+    assert out[1] == "scatter price mpg"
+    assert "graph export" in out[2] and "stata_graph_" in out[2]
+    assert out[3] == "summarize price"
+
+
+def test_export_after_first_line_graph():
+    out = maybe_inject_graph_export("scatter price mpg", TMP).split("\n")
+    assert out[0] == "scatter price mpg"
+    assert "graph export" in out[1]
+
+
+def test_continuation_block_export_after_full_command():
+    out = maybe_inject_graph_export(
+        "twoway (line y x) ///\n   (scatter y x), title(t)\nsummarize x", TMP
+    ).split("\n")
+    assert _export_indices("\n".join(out)) == [2]
+    assert out[3] == "summarize x"
+
+
+def test_non_rendering_graph_subcommands_not_injected():
+    for mgmt in (
+        "graph drop g1",
+        "graph dir",
+        "graph describe",
+        "graph rename a b",
+        "graph close",
+        "graph set window fontface",
+    ):
+        assert maybe_inject_graph_export(mgmt, TMP) == mgmt, mgmt
+
+
+def test_graph_drop_then_real_graph_injects_once_after_render():
+    out = maybe_inject_graph_export("graph drop g1\nscatter x y", TMP).split("\n")
+    assert out[0] == "graph drop g1"
+    assert out[1] == "scatter x y"
+    assert _export_indices("\n".join(out)) == [2]
+
+
+def test_no_injection_without_graph_command():
+    code = "regress y x\nsummarize x"
+    assert maybe_inject_graph_export(code, TMP) == code
+
+
+def test_no_injection_when_export_already_present():
+    code = 'scatter y x\ngraph export "mine.png", replace'
+    assert maybe_inject_graph_export(code, TMP) == code

--- a/tests/test_install_package.py
+++ b/tests/test_install_package.py
@@ -1,0 +1,88 @@
+"""Unit tests for the install_package tool (no Stata required).
+
+Uses a fake session that records the Stata code it is asked to run, so the
+handler's check/install logic is verified deterministically.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from stata_ai_fusion.stata_session import ExecutionResult
+from stata_ai_fusion.tools.install_package import _parse_check_rc, handle
+
+
+def test_parse_check_rc():
+    assert _parse_check_rc("__stata_pkg_rc=0") == 0
+    assert _parse_check_rc("__stata_pkg_rc=111") == 111
+    # Tolerates surrounding output / command echoes.
+    assert _parse_check_rc('. display "__stata_pkg_rc=" _rc\n__stata_pkg_rc=0\n') == 0
+    assert _parse_check_rc("no marker here") is None
+    assert _parse_check_rc("") is None
+    assert _parse_check_rc(None) is None
+
+
+class _FakeSession:
+    """Records executed code; returns the configured `which` rc, success otherwise."""
+
+    def __init__(self, which_rc: int | None) -> None:
+        self._which_rc = which_rc
+        self.calls: list[str] = []
+
+    async def execute(self, code: str, timeout: int = 120) -> ExecutionResult:
+        self.calls.append(code)
+        if "capture which" in code:
+            out = "" if self._which_rc is None else f"__stata_pkg_rc={self._which_rc}"
+            return ExecutionResult(output=out, return_code=0)
+        # ssc/net install: pretend it succeeded.
+        return ExecutionResult(output="installation complete", return_code=0)
+
+    def ran_install(self) -> bool:
+        return any("install" in c for c in self.calls)
+
+
+class _FakeManager:
+    def __init__(self, session: _FakeSession) -> None:
+        self._session = session
+
+    async def get_or_create(self, session_id: str) -> _FakeSession:
+        return self._session
+
+
+async def test_already_installed_skips_install():
+    sess = _FakeSession(which_rc=0)
+    result = await handle(_FakeManager(sess), {"package": "estout"})
+    assert "already installed" in result[0].text.lower()
+    assert not sess.ran_install()  # must NOT attempt install when present
+
+
+async def test_missing_package_triggers_install():
+    """Regression: a missing package (rc=111) must actually be installed,
+    not reported as 'already installed'."""
+    sess = _FakeSession(which_rc=111)
+    result = await handle(_FakeManager(sess), {"package": "estout"})
+    assert "already installed" not in result[0].text.lower()
+    assert sess.ran_install()
+    assert any("ssc install estout" in c for c in sess.calls)
+
+
+async def test_unknown_marker_falls_through_to_install():
+    """If the rc marker is missing (unexpected), be safe and attempt install."""
+    sess = _FakeSession(which_rc=None)
+    await handle(_FakeManager(sess), {"package": "estout"})
+    assert sess.ran_install()
+
+
+async def test_invalid_package_name_rejected():
+    sess = _FakeSession(which_rc=111)
+    result = await handle(_FakeManager(sess), {"package": "evil; shell rm -rf /"})
+    assert "only alphanumerics" in result[0].text.lower()
+    assert sess.calls == []  # rejected before touching Stata
+
+
+@pytest.mark.parametrize("empty", ["", "   "])
+async def test_empty_package_name_rejected(empty: str):
+    sess = _FakeSession(which_rc=0)
+    result = await handle(_FakeManager(sess), {"package": empty})
+    assert "no package name" in result[0].text.lower()
+    assert sess.calls == []

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,7 @@ from stata_ai_fusion.stata_discovery import discover_stata_or_none
 from stata_ai_fusion.stata_session import (
     BatchSession,
     ExecutionResult,
+    PipeSession,
     StataSession,
     strip_smcl,
 )
@@ -24,6 +25,69 @@ requires_stata = pytest.mark.skipif(
     discover_stata_or_none() is None,
     reason="Stata not installed",
 )
+
+
+# ---------------------------------------------------------------------------
+# PipeSession (persistent, no-PTY fallback)
+# ---------------------------------------------------------------------------
+
+
+@requires_stata
+class TestPipeSessionPersistence:
+    """The persistent pipe fallback must keep in-memory state between calls.
+
+    Unlike the interactive :class:`StataSession`, :class:`PipeSession` needs
+    no PTY, so these tests run even in sandboxed environments that deny
+    ``openpty`` (where the interactive fixtures are skipped/errored).
+    """
+
+    async def _new(self) -> PipeSession:
+        installation = discover_stata_or_none()
+        assert installation is not None
+        s = PipeSession(installation)
+        await s.start()
+        return s
+
+    async def test_data_persists_between_calls(self):
+        """Data loaded in one execute() must survive into the next call."""
+        s = await self._new()
+        try:
+            await s.execute("sysuse auto, clear")
+            result = await s.execute("count")  # separate call, same process
+            assert result.return_code == 0
+            assert "74" in result.output
+        finally:
+            await s.close()
+
+    async def test_stored_results_persist_across_calls(self):
+        """e()-class results from a regression must be readable in a later call."""
+        s = await self._new()
+        try:
+            await s.execute("sysuse auto, clear")
+            await s.execute("regress price mpg")
+            result = await s.execute("display e(N)")
+            assert "74" in result.output
+        finally:
+            await s.close()
+
+    async def test_session_survives_error(self):
+        """An error in one call must not kill the persistent session."""
+        s = await self._new()
+        try:
+            bad = await s.execute("this_is_not_a_command")
+            assert bad.return_code == 1
+            assert s.is_alive is True
+            ok = await s.execute("display 1+1")
+            assert "2" in ok.output
+        finally:
+            await s.close()
+
+    async def test_close_releases_process(self):
+        """close() must terminate the process and report not-alive."""
+        s = await self._new()
+        assert s.is_alive is True
+        await s.close()
+        assert s.is_alive is False
 
 
 # ---------------------------------------------------------------------------
@@ -265,7 +329,48 @@ class TestMultiSession:
         assert "second" in ids
         for entry in listing:
             assert entry["alive"] is True
-            assert entry["type"] in ("interactive", "batch")
+            assert entry["type"] in ("interactive", "batch", "pipe")
+
+    async def test_concurrent_same_id_dedup(self, session_manager):
+        """Concurrent get_or_create for one id must return one shared session.
+
+        Exercises the reserve-then-start-outside-the-lock path: only one caller
+        should create the session; the others wait and receive the same object.
+        """
+        import anyio
+
+        results: list = []
+
+        async def grab() -> None:
+            results.append(await session_manager.get_or_create("concurrent"))
+
+        async with anyio.create_task_group() as tg:
+            for _ in range(4):
+                tg.start_soon(grab)
+
+        assert len(results) == 4
+        assert all(s is results[0] for s in results)
+        assert results[0].is_alive is True
+
+    async def test_cancel_during_create_does_not_deadlock(self, session_manager):
+        """Cancelling a creation mid-boot must not leak the _creating Event.
+
+        Regression guard: if the per-id creation Event were left unset, every
+        later get_or_create for that id would block forever on wait_event.
+        """
+        import anyio
+
+        # Cancel the first creation while Stata is still booting.
+        with anyio.move_on_after(0.3):
+            await session_manager.get_or_create("cancel_race")
+
+        # The Event must have been cleaned up: a fresh call must NOT hang and
+        # must yield a working session.
+        with anyio.fail_after(90):
+            s = await session_manager.get_or_create("cancel_race")
+        assert s.is_alive is True
+        # No half-created session should linger under another id.
+        assert "cancel_race" in {e["session_id"] for e in await session_manager.list_sessions()}
 
     async def test_close_single_session(self, session_manager):
         """close_session() should remove exactly one session."""

--- a/tests/test_result_extractor_security.py
+++ b/tests/test_result_extractor_security.py
@@ -1,0 +1,79 @@
+"""Security/validation tests for ResultExtractor (no Stata required).
+
+Stored-result names reach get_scalar/get_matrix/get_macro and are interpolated
+into executed Stata code, so a crafted name must be rejected before execution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from stata_ai_fusion.result_extractor import ResultExtractor
+from stata_ai_fusion.stata_session import ExecutionResult
+
+
+def test_validate_result_name_accepts_identifiers():
+    for name in ("N", "mean", "r2", "_cons", "depvar", "F", "df_r", "rmse"):
+        assert ResultExtractor._validate_result_name(name) == name
+    # surrounding whitespace is trimmed
+    assert ResultExtractor._validate_result_name("  N  ") == "N"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "N)",
+        'N)\nshell echo pwned > /tmp/x\n*',
+        "N) ssc install foo",
+        "a b",
+        "",
+        "1abc",
+        "b[1,2]",
+        "$macro",
+        "`local'",
+        'N";display "x',
+    ],
+)
+def test_validate_result_name_rejects_injection(bad: str):
+    with pytest.raises(ValueError):
+        ResultExtractor._validate_result_name(bad)
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def execute(self, code: str, timeout: int = 120) -> ExecutionResult:
+        self.calls.append(code)
+        return ExecutionResult(output="74", return_code=0)
+
+
+async def test_get_scalar_rejects_bad_name_without_executing():
+    sess = _RecordingSession()
+    ext = ResultExtractor(sess)
+    with pytest.raises(ValueError):
+        await ext.get_scalar("N)\nshell evil", "e")
+    assert sess.calls == []  # never reached Stata
+
+
+async def test_get_matrix_rejects_bad_name_without_executing():
+    sess = _RecordingSession()
+    ext = ResultExtractor(sess)
+    with pytest.raises(ValueError):
+        await ext.get_matrix("b)\nshell evil", "e")
+    assert sess.calls == []
+
+
+async def test_get_macro_rejects_bad_name_without_executing():
+    sess = _RecordingSession()
+    ext = ResultExtractor(sess)
+    with pytest.raises(ValueError):
+        await ext.get_macro("depvar)\nshell evil", "e")
+    assert sess.calls == []
+
+
+async def test_get_scalar_valid_name_executes_expected_code():
+    sess = _RecordingSession()
+    ext = ResultExtractor(sess)
+    await ext.get_scalar("N", "r")
+    assert sess.calls == ["display r(N)"]

--- a/vscode-extension/src/mcpBridge.ts
+++ b/vscode-extension/src/mcpBridge.ts
@@ -137,6 +137,12 @@ export class McpBridge {
 
                 initResult
                     .then(() => {
+                        // Per the MCP lifecycle, the client must send the
+                        // `notifications/initialized` notification after the
+                        // initialize response and before any other request;
+                        // stricter/newer servers reject the first tools/call
+                        // without it.
+                        this.sendNotification('notifications/initialized');
                         this.started = true;
                         this.outputChannel.appendLine(
                             '[MCP Bridge] MCP server initialized.'
@@ -208,6 +214,21 @@ export class McpBridge {
                 }
             });
         });
+    }
+
+    /**
+     * Send a JSON-RPC notification (no `id`, no response expected).
+     */
+    private sendNotification(
+        method: string,
+        params?: Record<string, unknown>
+    ): void {
+        if (!this.process?.stdin?.writable) {
+            return;
+        }
+        const message =
+            JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n';
+        this.process.stdin.write(message);
     }
 
     /**
@@ -297,14 +318,14 @@ export class McpBridge {
      * Run a Stata command string.
      */
     async runCommand(code: string): Promise<McpToolResult> {
-        return this.callTool('run_command', { code });
+        return this.callTool('stata_run_command', { code });
     }
 
     /**
      * Run a Stata .do file by path.
      */
     async runDoFile(filePath: string): Promise<McpToolResult> {
-        return this.callTool('run_do_file', { file_path: filePath });
+        return this.callTool('stata_run_do_file', { path: filePath });
     }
 
     /**

--- a/vscode-extension/src/mcpConfig.ts
+++ b/vscode-extension/src/mcpConfig.ts
@@ -138,16 +138,51 @@ export async function autoConfigureMcp(): Promise<void> {
         args: ['--from', 'stata-ai-fusion', 'stata-ai-fusion'],
     };
 
-    // Read existing config or start fresh
+    // Read existing config, or start fresh if the file does not exist.
+    //
+    // IMPORTANT: if the file exists but cannot be read/parsed (e.g. it contains
+    // JSONC comments, which VS Code's mcp.json allows, or was hand-edited), we
+    // must NOT fall back to an empty object and rewrite it — that would delete
+    // every other MCP server the user has configured.  Skip auto-config
+    // instead and leave the file untouched.
     let config: McpConfig = {};
-    try {
-        if (fs.existsSync(configPath)) {
-            const content = fs.readFileSync(configPath, 'utf-8');
-            config = JSON.parse(content) as McpConfig;
+    if (fs.existsSync(configPath)) {
+        let content: string;
+        try {
+            content = fs.readFileSync(configPath, 'utf-8');
+        } catch (err) {
+            console.warn(
+                `[stata-ai-fusion] Could not read ${configPath}; ` +
+                    'skipping MCP auto-config.',
+                err
+            );
+            return;
         }
-    } catch {
-        // If the file is corrupt or unreadable, start with empty config
-        config = {};
+        try {
+            config = JSON.parse(content) as McpConfig;
+        } catch (err) {
+            console.warn(
+                `[stata-ai-fusion] ${configPath} is not strict JSON ` +
+                    '(comments?); skipping MCP auto-config to avoid overwriting ' +
+                    'your other MCP servers. Add the "stata-ai-fusion" entry ' +
+                    'manually if needed.',
+                err
+            );
+            return;
+        }
+        // Guard against a structurally-unexpected file (null/array/primitive):
+        // don't risk overwriting it.
+        if (
+            typeof config !== 'object' ||
+            config === null ||
+            Array.isArray(config)
+        ) {
+            console.warn(
+                `[stata-ai-fusion] ${configPath} is not a JSON object; ` +
+                    'skipping MCP auto-config to avoid overwriting it.'
+            );
+            return;
+        }
     }
 
     // Initialize mcpServers if missing


### PR DESCRIPTION
Fixes six bugs diagnosed across the MCP server and the VS Code extension. Each was reproduced, fixed at the root, tested, and reviewed.

## Fixes

1. **Session state did not persist on PTY-denied hosts.** Sandboxed launches fall back from the interactive (pexpect) session, and the old fallback was a *stateless* batch session that spawned a fresh `stata -b` process per call — so data/scalars/macros/`e()`-results did not persist between tool calls and `stata_cancel_command` was a no-op. Adds a persistent `PipeSession` (one long-lived `stata -q`, driven over stdin, output read from a named log via sentinels). Fallback is now PTY → PipeSession → batch; cancellation works (SIGINT to the process group); session creation runs outside the manager lock; startup is hardened against process/temp-dir leaks on failure/cancel.
2. **Graph auto-export off-by-one.** For a graph command not on the first line, the injected `graph export` was placed *before* it → Stata `r(601)`, no image. Anchored the pattern with `^`/`re.MULTILINE`; also excludes non-rendering `graph` subcommands (`drop`, `dir`, …).
3. **`install_package` never installed missing packages.** `capture which` suppressed the "not found"/`r(111)`, so every missing package was reported "already installed". Now reads `_rc` explicitly.
4. **Error-detection false positives.** A return code merely mentioned in output text (e.g. `display "see r(198)"`) was reported as an error. Detection is anchored to `^r(NNN);` (Stata's real error line).
5. **Broken `echo` parameter.** `echo=false` injected `set output inform`, which suppresses *results* (not echoes) and was never reset, poisoning every later command in a persistent session. Removed the injection and the parameter.
6. **`get_results` command injection.** The `keys` field reached executed Stata code unvalidated, so a crafted key could run arbitrary Stata/OS commands through a read-only tool. Stored-result names are now validated against a Stata-identifier whitelist before interpolation (`get_scalar`/`get_matrix`/`get_macro`).
7. **VS Code extension.** Wrong tool names/arg (`run_command`→`stata_run_command`, `file_path`→`path`) made every run return "Unknown tool"; the client never sent `notifications/initialized`; and `autoConfigureMcp` wiped the user's other MCP servers when `mcp.json` contained JSONC comments or failed to parse. All fixed.

## Testing

- **123 tests pass**, ruff clean. New Stata-free suites: `test_graph_cache`, `test_install_package`, `test_error_detection`, `test_result_extractor_security`, plus PipeSession persistence / concurrency / cancellation tests.
- Verified end-to-end against a real Stata 19 (MP) install: persistence (`count`=74 across calls), `regress`→`get_results` across calls, graph capture, injection blocked (the `shell` payload created no file), and the VS Code protocol replayed against the real server (`stata_run_command` → `4`, no "Unknown tool"). Config-wipe fix verified by compiling the real TS and running `autoConfigureMcp` against JSONC/valid/null/array files.
- The 2 remaining failing integration tests are pre-existing **environment** failures (they instantiate the interactive session, which needs a PTY that is denied in this sandbox) — confirmed identical on the base commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback "pipe" session mode for environments where interactive terminal allocation is unavailable.
  * Introduced result-name validation to prevent code injection.

* **Bug Fixes**
  * Improved Stata error detection with better message extraction.
  * Enhanced package installation detection reliability.
  * Fixed MCP lifecycle initialization in VSCode extension.

* **VSCode Extension**
  * Updated tool names to `stata_run_command` and `stata_run_do_file`.
  * Improved configuration file handling robustness.
  * Removed `echo` input flag from run command.

* **Tests**
  * Added comprehensive test coverage for error detection, graph caching, package installation, result extraction security, and concurrent session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->