### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.3.0 (2026-06-22)
+
+### Added
+- **Persistent sessions without a PTY**: a new `PipeSession` keeps a single Stata process alive over stdin (output read from a log file) on hosts that deny PTY allocation (e.g. sandboxed launches). In-memory data, scalars, macros, and `e()`/`r()` results now persist between tool calls, and `stata_cancel_command` works. Fallback order is interactive (pexpect) → pipe → batch.
+- **`stata_install_package` `from_url`**: install from a custom `net install` source (an http(s) URL or absolute path, validated to block injection).
+
+### Fixed
+- **Graph auto-export off-by-one**: the injected `graph export` was placed *before* a graph command that wasn't on the first line (Stata `r(601)`, no image returned); it is now inserted after, and non-rendering `graph` subcommands (`drop`, `dir`, …) no longer trigger a spurious export.
+- **`stata_install_package` never installed missing packages**: `capture which` suppressed the "not found"/`r(111)`, so every missing package was reported "already installed"; the check now reads `_rc` explicitly.
+- **Error-detection false positives**: a return code merely mentioned in output text (e.g. `display "see r(198)"`) was reported as an error; detection is now anchored to `r(NNN);` at the start of a line.
+- **`stata_get_results` command injection**: the `keys` field reached executed Stata code unvalidated; stored-result names are now validated against a Stata-identifier whitelist (`get_scalar`/`get_matrix`/`get_macro`).
+- **Discovery picked the oldest Stata**: with several versions installed, the lexicographically-first glob match (the oldest) was chosen; it now selects the newest version, then the most capable edition.
+- **`stata_search_log` ReDoS**: a caller-supplied regex ran on the asyncio event loop with no timeout; the match loop now runs in a worker thread bounded by a timeout (and `context_lines` is clamped).
+- **Matrix parsing**: `get_matrix` returned `None` for symmetric (`symmetric e(V)[n,n]`, lower-triangle) and wide/wrapped matrices and emitted invalid-JSON `nan`; it now parses all three layouts and maps missing values to `null`.
+- **VS Code extension**: corrected the tool names (`run_command` → `stata_run_command`) and argument (`file_path` → `path`) so Run Selection/Run File work; the client now sends `notifications/initialized`; and `autoConfigureMcp` no longer deletes the user's other MCP servers when `mcp.json` contains JSONC comments or fails to parse.
+
+### Changed
+- **Removed the `echo` parameter** from `stata_run_command`: it injected `set output inform`, which suppressed *results* (not echoes) and, in a persistent session, was never reset — poisoning later commands. It had no correct implementation.
+- Documentation: corrected MCP tool names and examples in both READMEs.
+
 ## 0.2.2 (2026-02-27)
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ The AI will now reference the 5,653-line knowledge base when writing Stata code 
 # Search "Stata AI Fusion" in the Extensions panel
 
 # Option 2: From GitHub Release
-code --install-extension stata-ai-fusion-0.2.3.vsix
+code --install-extension stata-ai-fusion-0.3.0.vsix
 
 # Option 3: Cursor
-cursor --install-extension stata-ai-fusion-0.2.3.vsix
+cursor --install-extension stata-ai-fusion-0.3.0.vsix
 ```
 
 ---
@@ -476,11 +476,11 @@ cd vscode-extension && npm install && npm run build
 
 | Test Suite | Count | Requires Stata |
 |------------|------:|:--------------:|
-| `test_discovery.py` | 39 | No |
-| `test_integration.py` | 46 | Yes |
-| **Total** | **85** | |
+| Unit tests (discovery, result/matrix parsing, injection, ReDoS, graph, …) | 118 | No |
+| `test_integration.py` | 52 | Yes |
+| **Total** | **170** | |
 
-All 85 tests pass on Stata MP 19 (macOS arm64).
+The 118 unit tests run without Stata; all 170 pass on Stata MP 19 (macOS arm64).
 
 ---
 
@@ -503,7 +503,7 @@ stata-ai-fusion/
 │   ├── src/                 # TypeScript extension source (5 files)
 │   ├── syntaxes/            # TextMate grammar
 │   └── snippets/            # 30 code snippets
-├── tests/                   # 85 tests (39 unit + 46 integration)
+├── tests/                   # 170 tests (118 unit + 52 integration)
 ├── assets/                  # Icon, architecture diagrams
 └── pyproject.toml
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -121,10 +121,10 @@ AI 将在编写 Stata 代码时参考这个 5,653 行的知识库。
 # 方法 1: 在 VS Code 扩展面板搜索 "Stata AI Fusion"
 
 # 方法 2: 从 GitHub Release 下载
-code --install-extension stata-ai-fusion-0.2.3.vsix
+code --install-extension stata-ai-fusion-0.3.0.vsix
 
 # 方法 3: Cursor
-cursor --install-extension stata-ai-fusion-0.2.3.vsix
+cursor --install-extension stata-ai-fusion-0.3.0.vsix
 ```
 
 ---
@@ -287,11 +287,11 @@ cd vscode-extension && npm install && npm run build
 
 | 测试套件 | 数量 | 需要 Stata |
 |----------|-----:|:----------:|
-| `test_discovery.py` | 39 | 否 |
-| `test_integration.py` | 46 | 是 |
-| **合计** | **85** | |
+| 单元测试（发现、结果/矩阵解析、注入、ReDoS、图形等） | 118 | 否 |
+| `test_integration.py` | 52 | 是 |
+| **合计** | **170** | |
 
-全部 85 个测试在 Stata MP 19 (macOS arm64) 上通过。
+118 个单元测试无需 Stata；全部 170 个在 Stata MP 19 (macOS arm64) 上通过。
 
 ---
 
@@ -314,7 +314,7 @@ stata-ai-fusion/
 │   ├── src/                 # TypeScript 扩展源码（5 个文件）
 │   ├── syntaxes/            # TextMate 语法规则
 │   └── snippets/            # 30 个代码片段
-├── tests/                   # 85 个测试（39 单元 + 46 集成）
+├── tests/                   # 170 个测试（118 单元 + 52 集成）
 ├── assets/                  # 图标、架构图
 └── pyproject.toml
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stata-ai-fusion"
-version = "0.2.3"
+version = "0.3.0"
 description = "MCP Server + Skill for Stata: execute commands, inspect data, and generate high-quality Stata code with AI"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/stata_ai_fusion/__init__.py
+++ b/src/stata_ai_fusion/__init__.py
@@ -1,3 +1,3 @@
 """Stata AI Fusion — MCP Server + Skill for Stata."""
 
-__version__ = "0.2.3"
+__version__ = "0.3.0"

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -49,7 +49,7 @@ Or configure in your AI assistant's MCP settings:
 ### VS Code Extension
 
 ```bash
-code --install-extension stata-ai-fusion-0.2.3.vsix
+code --install-extension stata-ai-fusion-0.3.0.vsix
 ```
 
 ### Skill Only (Claude.ai)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "stata-ai-fusion",
   "displayName": "Stata AI Fusion",
   "description": "Run Stata code, view graphs, and get AI assistance — all in VS Code",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "publisher": "statafusion",
   "engines": { "vscode": "^1.85.0" },
   "categories": ["Programming Languages", "Data Science", "Machine Learning"],

--- a/vscode-extension/src/mcpBridge.ts
+++ b/vscode-extension/src/mcpBridge.ts
@@ -131,7 +131,7 @@ export class McpBridge {
                     capabilities: {},
                     clientInfo: {
                         name: 'stata-ai-fusion-vscode',
-                        version: '0.2.3',
+                        version: '0.3.0',
                     },
                 });
 


### PR DESCRIPTION
Release 0.3.0 — bundles the 11 fixes from #6 and #7 (session persistence, graph/install/error-detection/get-results/discovery/search_log/matrix fixes, VS Code extension, and the removed `echo` param). Version bump, 0.3.0 CHANGELOG entry, README tool-name + test-count refresh.