### PR TITLE
chore: release script + extension LICENSE/.vscodeignore

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Release helper for stata-ai-fusion.
+#
+# Builds the current version (from pyproject.toml) and publishes it to PyPI and
+# the VS Code Marketplace.  Credentials are read from the macOS login keychain
+# at runtime, so NO token lives in this file, in shell history, or in the repo.
+#
+# One-time keychain setup (already done once):
+#   security add-generic-password -a stata-pypi -s stata-ai-fusion-pypi-token -w '<pypi-token>' -U
+#   security add-generic-password -a stata-vsce -s stata-ai-fusion-vsce-pat   -w '<azure-pat>'  -U
+#
+# Usage:
+#   scripts/release.sh            # build + publish to PyPI + Marketplace
+#   scripts/release.sh --dry-run  # build + verify credentials, but DO NOT publish
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+VERSION="$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+echo ">> stata-ai-fusion release v${VERSION}$( [ "$DRY_RUN" = 1 ] && echo ' (dry run)' )"
+
+# --- credentials from the macOS keychain ---
+PYPI_TOKEN="$(security find-generic-password -s stata-ai-fusion-pypi-token -w)" \
+  || { echo "!! PyPI token not found in keychain (service: stata-ai-fusion-pypi-token)"; exit 1; }
+VSCE_PAT="$(security find-generic-password -s stata-ai-fusion-vsce-pat -w)" \
+  || { echo "!! VS Marketplace PAT not found in keychain (service: stata-ai-fusion-vsce-pat)"; exit 1; }
+echo ">> credentials loaded from keychain"
+
+# --- build ---
+rm -f dist/*.whl dist/*.tar.gz
+uv build >/dev/null
+( cd vscode-extension && ./node_modules/.bin/vsce package >/dev/null )
+echo ">> built dist/stata_ai_fusion-${VERSION}.{whl,tar.gz} + vscode-extension/stata-ai-fusion-${VERSION}.vsix"
+
+if [ "$DRY_RUN" = 1 ]; then
+  echo ">> dry run complete (nothing published)"
+  exit 0
+fi
+
+# --- publish ---
+UV_PUBLISH_TOKEN="$PYPI_TOKEN" uv publish "dist/stata_ai_fusion-${VERSION}"*
+echo ">> PyPI: published ${VERSION}"
+
+( cd vscode-extension && ./node_modules/.bin/vsce publish \
+    --packagePath "stata-ai-fusion-${VERSION}.vsix" -p "$VSCE_PAT" )
+echo ">> Marketplace: published ${VERSION}"
+
+echo ">> done -- v${VERSION} is live on PyPI and the VS Marketplace."

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -1,0 +1,12 @@
+# Files excluded from the packaged .vsix (everything else is included).
+# The TypeScript in src/ is bundled into dist/extension.js by esbuild, so the
+# sources, build config, and dev dependencies do not belong in the package.
+.vscode/**
+node_modules/**
+src/**
+tsconfig.json
+package-lock.json
+*.vsix
+.gitignore
+.vscodeignore
+**/*.map

--- a/vscode-extension/LICENSE
+++ b/vscode-extension/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2025 stata-ai-fusion contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adds a keychain-backed `scripts/release.sh` (build + publish to PyPI and the Marketplace, no secrets in the repo), and `vscode-extension/LICENSE` + `.vscodeignore` so the .vsix ships the license and drops the TypeScript sources (10 files vs 15, no vsce warnings). Packaging only — no code/version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release script for publishing Python packages to PyPI and VS Code Marketplace extensions, with dry-run mode for credential verification.
  * Configured VS Code extension packaging to exclude development files, build artifacts, and source code from distribution.

* **Documentation**
  * Added MIT License with copyright notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->